### PR TITLE
Add audit log foundation

### DIFF
--- a/controllers/accountsPayableController.js
+++ b/controllers/accountsPayableController.js
@@ -12,6 +12,7 @@
 
 import AccountsPayable from "../models/accountsPayableModel.js";
 import AccountsPayableService from '../services/accountsPayableService.js';
+import AuditLogService from "../services/auditLogService.js";
 import mailData from "../services/email/mailData.js";
 import { sendMail } from "../services/email/mail.cjs";
 
@@ -41,6 +42,15 @@ const attendTravelRequest = async (req, res) => {
       if (updated) {
         const { user_email, user_name, request_id, status } = await mailData(requestId);
         await sendMail(user_email, user_name, requestId, status);
+        await AuditLogService.recordAuditLogFromRequest(req, {
+          actionType: 'REQUEST_QUOTED',
+          entityType: 'Request',
+          entityId: requestId,
+          metadata: {
+            imposed_fee: imposedFee,
+            new_status,
+          },
+        });
         return res.status(200).json({
           message: "Travel request status updated successfully",
           requestId: requestId,
@@ -70,6 +80,17 @@ const validateReceiptsHandler = async (req, res) => {
     const result = await AccountsPayableService.validateReceiptsAndUpdateStatus(requestId);
     const { user_email, user_name, request_id, status } = await mailData(requestId);
     await sendMail(user_email, user_name, requestId, status);
+    if (result.updatedStatus !== null) {
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'REQUEST_RECEIPTS_VALIDATED',
+        entityType: 'Request',
+        entityId: requestId,
+        metadata: {
+          updated_status: result.updatedStatus,
+          message: result.message,
+        },
+      });
+    }
     res.status(200).json(result);
   } catch (err) {
     console.error('Error in validateReceiptsHandler:', err);
@@ -115,6 +136,14 @@ const validateReceipt = async (req, res) => {
     }
     
     if (approval == 0){
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'RECEIPT_REJECTED',
+        entityType: 'Receipt',
+        entityId: receiptId,
+        metadata: {
+          new_status: 'Rechazado',
+        },
+      });
       return res.status(200).json({
         summary: "Receipt rejected",
         value: {
@@ -125,6 +154,14 @@ const validateReceipt = async (req, res) => {
       });
     }
     else if (approval == 1){
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'RECEIPT_APPROVED',
+        entityType: 'Receipt',
+        entityId: receiptId,
+        metadata: {
+          new_status: 'Aprobado',
+        },
+      });
       return res.status(200).json({
         summary: "Receipt approved",
         value: {

--- a/controllers/accountsPayableController.js
+++ b/controllers/accountsPayableController.js
@@ -13,6 +13,7 @@
 import AccountsPayable from "../models/accountsPayableModel.js";
 import AccountsPayableService from '../services/accountsPayableService.js';
 import AuditLogService from "../services/auditLogService.js";
+import pool from "../database/config/db.js";
 import mailData from "../services/email/mailData.js";
 import { sendMail } from "../services/email/mail.cjs";
 
@@ -21,6 +22,7 @@ import { sendMail } from "../services/email/mail.cjs";
 const attendTravelRequest = async (req, res) => {
   const requestId = req.params.request_id;
   const imposedFee = req.body.imposed_fee;
+  let connection;
   
   try {
     // Check if request exists
@@ -37,11 +39,16 @@ const attendTravelRequest = async (req, res) => {
     if (current_status == 4){
       const new_status = 6;  // Always go to status 6 (receipts/comprobantes)
       
-      const updated = await AccountsPayable.attendTravelRequest(requestId, imposedFee, new_status);
+      connection = await pool.getConnection();
+      await connection.beginTransaction();
+      const updated = await AccountsPayable.attendTravelRequest(
+        requestId,
+        imposedFee,
+        new_status,
+        connection
+      );
       
       if (updated) {
-        const { user_email, user_name, request_id, status } = await mailData(requestId);
-        await sendMail(user_email, user_name, requestId, status);
         await AuditLogService.recordAuditLogFromRequest(req, {
           actionType: 'REQUEST_QUOTED',
           entityType: 'Request',
@@ -50,7 +57,14 @@ const attendTravelRequest = async (req, res) => {
             imposed_fee: imposedFee,
             new_status,
           },
-        });
+        }, { connection });
+        await connection.commit();
+        try {
+          const { user_email, user_name, request_id, status } = await mailData(requestId);
+          await sendMail(user_email, user_name, requestId, status);
+        } catch (mailError) {
+          console.error("Failed to send accounts payable quotation email:", mailError);
+        }
         return res.status(200).json({
           message: "Travel request status updated successfully",
           requestId: requestId,
@@ -58,6 +72,9 @@ const attendTravelRequest = async (req, res) => {
           newStatus: new_status, 
         });
       } else {
+        await connection.rollback();
+        connection.release();
+        connection = null;
         return res
         .status(400)
         .json({ error: "Failed to update travel request status" });
@@ -67,19 +84,25 @@ const attendTravelRequest = async (req, res) => {
       res.status(404).json({ error: "This request cannot be attended by accounts payable" });
     }
   } catch (err) {
+    if (connection) await connection.rollback();
     console.error("Error in attendTravelRequest controller:", err);
     res.status(500).json({ error: "Internal Server Error" });
+  } finally {
+    if (connection) connection.release();
   }
 };
 
 // Validate all receipts for a travel request and update status
 const validateReceiptsHandler = async (req, res) => {
   const requestId = req.params.request_id;
+  let connection;
   
   try {
-    const result = await AccountsPayableService.validateReceiptsAndUpdateStatus(requestId);
-    const { user_email, user_name, request_id, status } = await mailData(requestId);
-    await sendMail(user_email, user_name, requestId, status);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const result = await AccountsPayableService.validateReceiptsAndUpdateStatus(requestId, {
+      connection,
+    });
     if (result.updatedStatus !== null) {
       await AuditLogService.recordAuditLogFromRequest(req, {
         actionType: 'REQUEST_RECEIPTS_VALIDATED',
@@ -89,12 +112,22 @@ const validateReceiptsHandler = async (req, res) => {
           updated_status: result.updatedStatus,
           message: result.message,
         },
-      });
+      }, { connection });
+    }
+    await connection.commit();
+    try {
+      const { user_email, user_name, request_id, status } = await mailData(requestId);
+      await sendMail(user_email, user_name, requestId, status);
+    } catch (mailError) {
+      console.error("Failed to send receipts validation email:", mailError);
     }
     res.status(200).json(result);
   } catch (err) {
+    if (connection) await connection.rollback();
     console.error('Error in validateReceiptsHandler:', err);
     res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    if (connection) connection.release();
   }
 };
 
@@ -102,6 +135,7 @@ const validateReceiptsHandler = async (req, res) => {
 const validateReceipt = async (req, res) => {
   const receiptId = req.params.receipt_id;
   const approval = req.body.approval;
+  let connection;
   
   if (approval !== 0 && approval !== 1) {
     return res.status(400).json({
@@ -127,9 +161,14 @@ const validateReceipt = async (req, res) => {
      * the desired value for the validation (3 for rejected or 2 for
      * approved 
      */
-    const updated = await AccountsPayable.validateReceipt(receiptId, 3 - approval);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const updated = await AccountsPayable.validateReceipt(receiptId, 3 - approval, connection);
     
     if(!updated){
+      await connection.rollback();
+      connection.release();
+      connection = null;
       return res
       .status(400)
       .json({ error: "Failed to update travel request status" });
@@ -143,7 +182,8 @@ const validateReceipt = async (req, res) => {
         metadata: {
           new_status: 'Rechazado',
         },
-      });
+      }, { connection });
+      await connection.commit();
       return res.status(200).json({
         summary: "Receipt rejected",
         value: {
@@ -161,7 +201,8 @@ const validateReceipt = async (req, res) => {
         metadata: {
           new_status: 'Aprobado',
         },
-      });
+      }, { connection });
+      await connection.commit();
       return res.status(200).json({
         summary: "Receipt approved",
         value: {
@@ -173,8 +214,11 @@ const validateReceipt = async (req, res) => {
     }
     
   } catch (err) {
+    if (connection) await connection.rollback();
     console.error("Error in attendTravelRequest controller:", err);
     res.status(500).json({ error: "Internal Server Error" });
+  } finally {
+    if (connection) connection.release();
   }
 };
 

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -12,6 +12,7 @@
 import * as adminService from "../services/adminService.js";
 import Admin from "../models/adminModel.js";
 import userModel from "../models/userModel.js";
+import AuditLogService from "../services/auditLogService.js";
 
 /**
 * Get list of all users
@@ -50,6 +51,17 @@ export const createMultipleUsers = async (req, res) => {
   
   try {
     const result = await adminService.parseCSV(filePath, false);
+    if (result.created > 0) {
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'USER_BULK_CREATED',
+        entityType: 'User',
+        metadata: {
+          total_records: result.total_records,
+          created: result.created,
+          failed: result.failed,
+        },
+      });
+    }
     res.status(200).json(result);
   } catch (error) {
     console.error(error);
@@ -66,7 +78,17 @@ export const createMultipleUsers = async (req, res) => {
 export const createUser = async (req, res) => {
   try {
     const userData = req.body;
-    await adminService.createUser(userData);
+    const createdUser = await adminService.createUser(userData);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'USER_CREATED',
+      entityType: 'User',
+      entityId: createdUser.user_id,
+      metadata: {
+        user_name: createdUser.user_name,
+        role_id: createdUser.role_id,
+        department_id: createdUser.department_id,
+      },
+    });
     return res.status(201).json({ message: 'User created succesfully'});
   } catch (error) {
     console.error('Error creating user:', error.message);
@@ -80,6 +102,16 @@ export const updateUser = async (req, res) => {
     const userId = req.params.user_id;
     
     const result = await adminService.updateUserData(userId, req.body);
+    if (result.updated_fields) {
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'USER_UPDATED',
+        entityType: 'User',
+        entityId: userId,
+        metadata: {
+          updated_fields: result.updated_fields,
+        },
+      });
+    }
     return res.status(200).json(result);
     
   } catch (error) {
@@ -99,6 +131,16 @@ export const deactivateUser = async (req, res) => {
     }
     
     const result = await Admin.deactivateUserById(user_id);
+    if (result) {
+      await AuditLogService.recordAuditLogFromRequest(req, {
+        actionType: 'USER_DEACTIVATED',
+        entityType: 'User',
+        entityId: user_id,
+        metadata: {
+          active: false,
+        },
+      });
+    }
     
     return res.status(200).json({
       message: "User successfully deactivated",

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -13,6 +13,7 @@ import * as adminService from "../services/adminService.js";
 import Admin from "../models/adminModel.js";
 import userModel from "../models/userModel.js";
 import AuditLogService from "../services/auditLogService.js";
+import pool from "../database/config/db.js";
 
 /**
 * Get list of all users
@@ -51,17 +52,6 @@ export const createMultipleUsers = async (req, res) => {
   
   try {
     const result = await adminService.parseCSV(filePath, false);
-    if (result.created > 0) {
-      await AuditLogService.recordAuditLogFromRequest(req, {
-        actionType: 'USER_BULK_CREATED',
-        entityType: 'User',
-        metadata: {
-          total_records: result.total_records,
-          created: result.created,
-          failed: result.failed,
-        },
-      });
-    }
     res.status(200).json(result);
   } catch (error) {
     console.error(error);
@@ -76,9 +66,12 @@ export const createMultipleUsers = async (req, res) => {
 * @returns {Object} JSON response with created user data
 */
 export const createUser = async (req, res) => {
+  let connection;
   try {
     const userData = req.body;
-    const createdUser = await adminService.createUser(userData);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const createdUser = await adminService.createUser(userData, { connection });
     await AuditLogService.recordAuditLogFromRequest(req, {
       actionType: 'USER_CREATED',
       entityType: 'User',
@@ -88,20 +81,26 @@ export const createUser = async (req, res) => {
         role_id: createdUser.role_id,
         department_id: createdUser.department_id,
       },
-    });
+    }, { connection });
+    await connection.commit();
     return res.status(201).json({ message: 'User created succesfully'});
   } catch (error) {
+    if (connection) await connection.rollback();
     console.error('Error creating user:', error.message);
     return res.status(500).json({ error: 'Internal server error' });
+  } finally {
+    if (connection) connection.release();
   }
 }
 
 // Update existing user information
 export const updateUser = async (req, res) => {
+  let connection;
   try {
     const userId = req.params.user_id;
-    
-    const result = await adminService.updateUserData(userId, req.body);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const result = await adminService.updateUserData(userId, req.body, { connection });
     if (result.updated_fields) {
       await AuditLogService.recordAuditLogFromRequest(req, {
         actionType: 'USER_UPDATED',
@@ -110,18 +109,23 @@ export const updateUser = async (req, res) => {
         metadata: {
           updated_fields: result.updated_fields,
         },
-      });
+      }, { connection });
     }
+    await connection.commit();
     return res.status(200).json(result);
     
   } catch (error) {
+    if (connection) await connection.rollback();
     console.error('An error occurred updating the user:', error);
     return res.status(error.status || 500).json({ error: error.message || 'Internal server error' });
+  } finally {
+    if (connection) connection.release();
   }
 };
 
 // Deactivate user account (soft delete)
 export const deactivateUser = async (req, res) => {
+  let connection;
   try {
     const user_id = parseInt(req.params.user_id);
     
@@ -130,7 +134,9 @@ export const deactivateUser = async (req, res) => {
       return res.status(404).json({error: "User not found"});
     }
     
-    const result = await Admin.deactivateUserById(user_id);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const result = await Admin.deactivateUserById(user_id, connection);
     if (result) {
       await AuditLogService.recordAuditLogFromRequest(req, {
         actionType: 'USER_DEACTIVATED',
@@ -139,8 +145,9 @@ export const deactivateUser = async (req, res) => {
         metadata: {
           active: false,
         },
-      });
+      }, { connection });
     }
+    await connection.commit();
     
     return res.status(200).json({
       message: "User successfully deactivated",
@@ -148,10 +155,13 @@ export const deactivateUser = async (req, res) => {
       active: false
     });
   } catch (err) {
+    if (connection) await connection.rollback();
     console.error("Error in deactivateUser:", err);
     return res.status(500).json({
       error: "Unexpected error while deactivating user"
     });
+  } finally {
+    if (connection) connection.release();
   }
 }
 

--- a/controllers/auditLogController.js
+++ b/controllers/auditLogController.js
@@ -1,0 +1,21 @@
+/**
+ * Audit Log Controller
+ *
+ * Read-only handlers for audit trails.
+ */
+
+import AuditLogService from '../services/auditLogService.js';
+
+export async function getAuditLogs(req, res) {
+  try {
+    const response = await AuditLogService.getAuditLogs(req.query);
+    return res.status(200).json(response);
+  } catch (error) {
+    console.error('Error getting audit logs:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export default {
+  getAuditLogs,
+};

--- a/controllers/authorizerController.js
+++ b/controllers/authorizerController.js
@@ -10,6 +10,7 @@
  */
 import Authorizer from "../models/authorizerModel.js";
 import authorizerServices from "../services/authorizerService.js";
+import AuditLogService from "../services/auditLogService.js";
 import { sendMail } from "../services/email/mail.cjs";
 import mailData from "../services/email/mailData.js"
 
@@ -45,18 +46,30 @@ const getAlerts = async (req, res) => {
 
 // Approve travel request and send notification email
 const authorizeTravelRequest = async (req, res) => {
-  const { request_id, user_id } = req.params;
+  const requestId = Number(req.params.request_id);
+  const actorUserId = Number(req.user.user_id);
 
   try {
     // Authorize request through service layer
-    const { new_status } = await authorizerServices.authorizeRequest(Number(request_id), Number(user_id));
+    const result = await authorizerServices.authorizeRequest(requestId, actorUserId);
     
     // Send email notification to applicant
-    const { user_email, user_name, requestId, status } = await mailData(request_id);
-    await sendMail(user_email, user_name, request_id, status);
+    const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
+    await sendMail(user_email, user_name, mailRequestId, status);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'REQUEST_AUTHORIZED',
+      entityType: 'Request',
+      entityId: requestId,
+      metadata: {
+        new_assigned_to: result.new_assigned_to,
+        new_authorization_level: result.new_authorization_level,
+        new_status: result.new_status,
+        completed_all_authorizations: result.completed_all_authorizations,
+      },
+    });
     return res.status(200).json({
       message: "Request status updated successfully",
-      new_status
+      new_status: result.new_status
     });
   } catch (err) {
     if (err.status) {
@@ -69,15 +82,24 @@ const authorizeTravelRequest = async (req, res) => {
 
 // Decline travel request and send notification email
 const declineTravelRequest = async (req, res) => {
-  const { request_id, user_id } = req.params;
+  const requestId = Number(req.params.request_id);
+  const actorUserId = Number(req.user.user_id);
 
   try {
     // Decline request through service layer
-    const result = await authorizerServices.declineRequest(Number(request_id), Number(user_id));
+    const result = await authorizerServices.declineRequest(requestId, actorUserId);
     
     // Send email notification to applicant
-    const { user_email, user_name, requestId, status } = await mailData(request_id);
-    await sendMail(user_email, user_name, request_id, status);
+    const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
+    await sendMail(user_email, user_name, mailRequestId, status);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'REQUEST_DECLINED',
+      entityType: 'Request',
+      entityId: requestId,
+      metadata: {
+        new_status: result.new_status,
+      },
+    });
     return res.status(200).json(result); 
   } catch (err) {
     if (err.status) {

--- a/controllers/authorizerController.js
+++ b/controllers/authorizerController.js
@@ -11,6 +11,7 @@
 import Authorizer from "../models/authorizerModel.js";
 import authorizerServices from "../services/authorizerService.js";
 import AuditLogService from "../services/auditLogService.js";
+import pool from "../database/config/db.js";
 import { sendMail } from "../services/email/mail.cjs";
 import mailData from "../services/email/mailData.js"
 
@@ -48,14 +49,13 @@ const getAlerts = async (req, res) => {
 const authorizeTravelRequest = async (req, res) => {
   const requestId = Number(req.params.request_id);
   const actorUserId = Number(req.user.user_id);
+  let connection;
 
   try {
     // Authorize request through service layer
-    const result = await authorizerServices.authorizeRequest(requestId, actorUserId);
-    
-    // Send email notification to applicant
-    const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
-    await sendMail(user_email, user_name, mailRequestId, status);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const result = await authorizerServices.authorizeRequest(requestId, actorUserId, { connection });
     await AuditLogService.recordAuditLogFromRequest(req, {
       actionType: 'REQUEST_AUTHORIZED',
       entityType: 'Request',
@@ -66,17 +66,27 @@ const authorizeTravelRequest = async (req, res) => {
         new_status: result.new_status,
         completed_all_authorizations: result.completed_all_authorizations,
       },
-    });
+    }, { connection });
+    await connection.commit();
+    try {
+      const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
+      await sendMail(user_email, user_name, mailRequestId, status);
+    } catch (mailError) {
+      console.error("Failed to send request authorization email:", mailError);
+    }
     return res.status(200).json({
       message: "Request status updated successfully",
       new_status: result.new_status
     });
   } catch (err) {
+    if (connection) await connection.rollback();
     if (err.status) {
       return res.status(err.status).json({ error: err.message });
     }
     console.error("Unexpected error in authorizeTravelRequest controller:", err);
     return res.status(500).json({ error: "Internal server error" });
+  } finally {
+    if (connection) connection.release();
   }
 };
 
@@ -84,14 +94,13 @@ const authorizeTravelRequest = async (req, res) => {
 const declineTravelRequest = async (req, res) => {
   const requestId = Number(req.params.request_id);
   const actorUserId = Number(req.user.user_id);
+  let connection;
 
   try {
     // Decline request through service layer
-    const result = await authorizerServices.declineRequest(requestId, actorUserId);
-    
-    // Send email notification to applicant
-    const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
-    await sendMail(user_email, user_name, mailRequestId, status);
+    connection = await pool.getConnection();
+    await connection.beginTransaction();
+    const result = await authorizerServices.declineRequest(requestId, actorUserId, { connection });
     await AuditLogService.recordAuditLogFromRequest(req, {
       actionType: 'REQUEST_DECLINED',
       entityType: 'Request',
@@ -99,14 +108,24 @@ const declineTravelRequest = async (req, res) => {
       metadata: {
         new_status: result.new_status,
       },
-    });
+    }, { connection });
+    await connection.commit();
+    try {
+      const { user_email, user_name, requestId: mailRequestId, status } = await mailData(requestId);
+      await sendMail(user_email, user_name, mailRequestId, status);
+    } catch (mailError) {
+      console.error("Failed to send request decline email:", mailError);
+    }
     return res.status(200).json(result); 
   } catch (err) {
+    if (connection) await connection.rollback();
     if (err.status) {
       return res.status(err.status).json({ error: err.message });
     }
     console.error("Unexpected error in declineTravelRequest controller:", err);
     return res.status(500).json({ error: "Internal server error" });
+  } finally {
+    if (connection) connection.release();
   }
 };
 

--- a/database/Schema/Scheme.sql
+++ b/database/Schema/Scheme.sql
@@ -55,6 +55,24 @@ CREATE TABLE IF NOT EXISTS User (
     FOREIGN KEY (boss_id) REFERENCES User(user_id)
 );
 
+-- Audit_Log: Critical action trail for administrative and workflow events
+CREATE TABLE IF NOT EXISTS Audit_Log (
+    audit_log_id INT PRIMARY KEY AUTO_INCREMENT,
+    actor_user_id INT NULL,                  -- Authenticated user who executed the action
+    action_type VARCHAR(80) NOT NULL,        -- Action performed (e.g., USER_CREATED)
+    entity_type VARCHAR(80) NOT NULL,        -- Entity affected (e.g., User, Request, Receipt)
+    entity_id VARCHAR(64) NULL,              -- Generic identifier for the affected entity
+    source_ip VARCHAR(45) NULL,              -- Request IP address (IPv4/IPv6)
+    metadata LONGTEXT NULL,                  -- Sanitized contextual payload serialized as JSON
+    event_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (actor_user_id) REFERENCES User(user_id),
+    INDEX idx_audit_actor (actor_user_id),
+    INDEX idx_audit_entity (entity_type, entity_id),
+    INDEX idx_audit_action (action_type),
+    INDEX idx_audit_timestamp (event_timestamp)
+);
+
 -- ============================================================================
 -- Request Management Tables
 -- ============================================================================

--- a/database/Schema/patches/2026-03-27_audit_log_foundation.sql
+++ b/database/Schema/patches/2026-03-27_audit_log_foundation.sql
@@ -1,0 +1,18 @@
+USE CocoScheme;
+
+CREATE TABLE IF NOT EXISTS Audit_Log (
+    audit_log_id INT PRIMARY KEY AUTO_INCREMENT,
+    actor_user_id INT NULL,
+    action_type VARCHAR(80) NOT NULL,
+    entity_type VARCHAR(80) NOT NULL,
+    entity_id VARCHAR(64) NULL,
+    source_ip VARCHAR(45) NULL,
+    metadata LONGTEXT NULL,
+    event_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (actor_user_id) REFERENCES User(user_id),
+    INDEX idx_audit_actor (actor_user_id),
+    INDEX idx_audit_entity (entity_type, entity_id),
+    INDEX idx_audit_action (action_type),
+    INDEX idx_audit_timestamp (event_timestamp)
+);

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ import accountsPayableRoutes from './routes/accountsPayableRoutes.js';
 import fileRoutes from './routes/fileRoutes.js';
 import systemRoutes from "./routes/systemRoutes.js";
 import exchangeRateRoutes from "./routes/exchangeRateRoutes.js";
+import auditLogRoutes from "./routes/auditLogRoutes.js";
 
 // Import MongoDB connection for file storage
 import { connectMongo } from './services/fileStorage.js';
@@ -58,6 +59,7 @@ app.use("/api/accounts-payable", accountsPayableRoutes);
 app.use("/api/files", fileRoutes);
 app.use("/api/system", systemRoutes);
 app.use("/api/exchange-rate", exchangeRateRoutes);
+app.use("/api/audit-log", auditLogRoutes);
 // Connect to MongoDB for file storage
 connectMongo().catch(err => console.error('Failed to connect to MongoDB:', err));
 

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -6,7 +6,7 @@
  * request bodies, and ensures data integrity using express-validator.
  */
 
-import { body, param, validationResult } from 'express-validator';
+import { body, param, query, validationResult } from 'express-validator';
 
 // Validate and sanitize ID parameters in endpoints
 export const validateId = [
@@ -506,6 +506,51 @@ export const validateCreateUser = [
     .withMessage('Phone number cannot be empty.')
 ];
 
+// Validate audit log query parameters
+export const validateAuditLogQuery = [
+  query('actor_user_id')
+    .optional()
+    .isInt({ min: 1 })
+    .toInt()
+    .withMessage('actor_user_id must be a valid positive integer'),
+  query('action_type')
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .isLength({ max: 80 })
+    .withMessage('action_type must be a non-empty string up to 80 characters'),
+  query('entity_type')
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .isLength({ max: 80 })
+    .withMessage('entity_type must be a non-empty string up to 80 characters'),
+  query('entity_id')
+    .optional()
+    .isString()
+    .trim()
+    .notEmpty()
+    .isLength({ max: 64 })
+    .withMessage('entity_id must be a non-empty string up to 64 characters'),
+  query('include_metadata')
+    .optional()
+    .isBoolean()
+    .toBoolean()
+    .withMessage('include_metadata must be a boolean value'),
+  query('limit')
+    .optional()
+    .isInt({ min: 1, max: 200 })
+    .toInt()
+    .withMessage('limit must be an integer between 1 and 200'),
+  query('offset')
+    .optional()
+    .isInt({ min: 0 })
+    .toInt()
+    .withMessage('offset must be a non-negative integer'),
+];
+
 // Generic validation error handler
 export const validateInputs = (req, res, next) => {
   const errors = validationResult(req);
@@ -521,5 +566,6 @@ export default {
   validateExpenseReceipts,
   validateInputs,
   validateDraftTravelRequest,
-  validateCreateUser
+  validateCreateUser,
+  validateAuditLogQuery
 };

--- a/models/accountsPayableModel.js
+++ b/models/accountsPayableModel.js
@@ -10,11 +10,10 @@ import pool from "../database/config/db.js";
 
 const AccountsPayable = {
   // Update request status to 5 (Atención Agencia de Viajes)
-  async attendTravelRequest(requestId, imposedFee, new_status) {
+  async attendTravelRequest(requestId, imposedFee, new_status, connection = null) {
     let conn;
     try {
-      // Get a connection from the pool
-      conn = await pool.getConnection();
+      conn = connection || (await pool.getConnection());
       const result = await conn.query(
         `UPDATE Request SET request_status_id = ?, imposed_fee = ? 
         WHERE request_id = ?`,
@@ -28,7 +27,7 @@ const AccountsPayable = {
       throw error;
 
     } finally {
-      if (conn) {
+      if (!connection && conn) {
         conn.release();
       }
     }
@@ -79,7 +78,7 @@ const AccountsPayable = {
     }
   },
   
-  async updateRequestStatus(requestId, statusId) {
+  async updateRequestStatus(requestId, statusId, connection = null) {
     let conn;
     const query = `
       UPDATE Request
@@ -88,7 +87,7 @@ const AccountsPayable = {
     `;
     
     try {
-      conn = await pool.getConnection();
+      conn = connection || (await pool.getConnection());
       await conn.query(query, [statusId, requestId]);
 
     } catch (error) {
@@ -96,7 +95,7 @@ const AccountsPayable = {
       throw error;
 
     } finally {
-      if (conn) conn.release();
+      if (!connection && conn) conn.release();
     }
   },
   
@@ -123,10 +122,10 @@ const AccountsPayable = {
   },
   
   // Accept or Reject a Travel Request
-  async validateReceipt(requestId, approval) {
+  async validateReceipt(requestId, approval, connection = null) {
     let conn;
     try {
-      conn = await pool.getConnection();
+      conn = connection || (await pool.getConnection());
       const result = await conn.query(
         `UPDATE Receipt
         SET validation = ? WHERE receipt_id = ?`,
@@ -139,7 +138,7 @@ const AccountsPayable = {
       throw error;
 
     } finally {
-      if (conn) {
+      if (!connection && conn) {
         conn.release();
       }
     }

--- a/models/adminModel.js
+++ b/models/adminModel.js
@@ -164,7 +164,7 @@ const Admin = {
           throw new Error('User with this email or username already exists');
         }
         
-        await connection.query(`
+        const result = await connection.query(`
           INSERT INTO User (
             role_id,
             department_id,
@@ -186,6 +186,10 @@ const Admin = {
             userData.phone_number
           ]
         );
+
+        return {
+          user_id: result.insertId,
+        };
       } finally {
         connection.release();
       }

--- a/models/adminModel.js
+++ b/models/adminModel.js
@@ -32,9 +32,8 @@ const Admin = {
     },
     
     // Create multiple users in a single batch operation
-    async createMultipleUsers(users) {
+    async createMultipleUsers(users, connection = null) {
       let conn;
-      
       const values = users.map(user => [
         user.role_id,
         user.department_id,
@@ -61,7 +60,7 @@ const Admin = {
       `;
       
       try {
-        conn = await pool.getConnection();
+        conn = connection || (await pool.getConnection());
         const result = await conn.batch(query, values);
         return result.affectedRows;
         
@@ -70,7 +69,7 @@ const Admin = {
         throw error;
         
       } finally {
-        if (conn){
+        if (!connection && conn){
           conn.release();
         } 
       }
@@ -151,10 +150,11 @@ const Admin = {
     },
     
     // Create a single user
-    async createUser(userData) {
-      const connection = await db.getConnection();
+    async createUser(userData, connection = null) {
+      let conn;
+      conn = connection || (await db.getConnection());
       try{
-        const existingUser = await connection.query(`
+        const existingUser = await conn.query(`
           SELECT user_id FROM User
           WHERE email = ? OR user_name = ?`,
           [userData.email, userData.user_name]
@@ -164,7 +164,7 @@ const Admin = {
           throw new Error('User with this email or username already exists');
         }
         
-        const result = await connection.query(`
+        const result = await conn.query(`
           INSERT INTO User (
             role_id,
             department_id,
@@ -191,7 +191,7 @@ const Admin = {
           user_id: result.insertId,
         };
       } finally {
-        connection.release();
+        if (!connection) conn.release();
       }
     },
     
@@ -218,9 +218,8 @@ const Admin = {
     },
     
     // Update user information
-    async updateUser(user_id, fieldsToUpdate) {
+    async updateUser(user_id, fieldsToUpdate, connection = null) {
       let conn;
-      
       const setClauses = [];
       const values =[];
       
@@ -237,7 +236,7 @@ const Admin = {
         WHERE user_id = ?
       `;
       try {
-        conn = await pool.getConnection();
+        conn = connection || (await pool.getConnection());
         const result = await conn.query(query, values);
         return result;
 
@@ -245,15 +244,15 @@ const Admin = {
         throw error;
 
       } finally {
-        if (conn) conn.release();
+        if (!connection && conn) conn.release();
       }
     },
     
     // Deactivate a user by ID
-    async deactivateUserById(userId) {
+    async deactivateUserById(userId, connection = null) {
       let conn;
       try {
-        conn = await pool.getConnection();
+        conn = connection || (await pool.getConnection());
         const result = await conn.query(
           `UPDATE User SET active = FALSE WHERE user_id = ?`,
           [userId]
@@ -265,7 +264,7 @@ const Admin = {
         throw error;
         
       } finally {
-        if (conn) {
+        if (!connection && conn) {
           conn.release();
         }
       }

--- a/models/auditLogModel.js
+++ b/models/auditLogModel.js
@@ -38,11 +38,10 @@ function buildAuditFilters(filters) {
 
 function buildAuditLogModel({ dbPool = pool } = {}) {
   return {
-    async createAuditLog(entry) {
-      let conn;
+    async createAuditLog(entry, connection = null) {
+      const conn = connection || (await dbPool.getConnection());
 
       try {
-        conn = await dbPool.getConnection();
         const result = await conn.query(
           `INSERT INTO Audit_Log (
              actor_user_id,
@@ -66,7 +65,7 @@ function buildAuditLogModel({ dbPool = pool } = {}) {
           audit_log_id: result.insertId,
         };
       } finally {
-        if (conn) conn.release();
+        if (!connection) conn.release();
       }
     },
 

--- a/models/auditLogModel.js
+++ b/models/auditLogModel.js
@@ -1,0 +1,121 @@
+/**
+ * Audit Log Model
+ *
+ * Data access for critical action logs.
+ */
+
+import pool from '../database/config/db.js';
+
+function buildAuditFilters(filters) {
+  const clauses = [];
+  const params = [];
+
+  if (filters.actor_user_id !== null) {
+    clauses.push('al.actor_user_id = ?');
+    params.push(filters.actor_user_id);
+  }
+
+  if (filters.action_type) {
+    clauses.push('al.action_type = ?');
+    params.push(filters.action_type);
+  }
+
+  if (filters.entity_type) {
+    clauses.push('al.entity_type = ?');
+    params.push(filters.entity_type);
+  }
+
+  if (filters.entity_id) {
+    clauses.push('al.entity_id = ?');
+    params.push(filters.entity_id);
+  }
+
+  return {
+    whereClause: clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '',
+    params,
+  };
+}
+
+function buildAuditLogModel({ dbPool = pool } = {}) {
+  return {
+    async createAuditLog(entry) {
+      let conn;
+
+      try {
+        conn = await dbPool.getConnection();
+        const result = await conn.query(
+          `INSERT INTO Audit_Log (
+             actor_user_id,
+             action_type,
+             entity_type,
+             entity_id,
+             source_ip,
+             metadata
+           ) VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            entry.actor_user_id,
+            entry.action_type,
+            entry.entity_type,
+            entry.entity_id,
+            entry.source_ip,
+            entry.metadata,
+          ]
+        );
+
+        return {
+          audit_log_id: result.insertId,
+        };
+      } finally {
+        if (conn) conn.release();
+      }
+    },
+
+    async getAuditLogs(filters) {
+      let conn;
+
+      try {
+        conn = await dbPool.getConnection();
+        const { whereClause, params } = buildAuditFilters(filters);
+
+        const rows = await conn.query(
+          `SELECT
+             al.audit_log_id,
+             al.actor_user_id,
+             actor.user_name AS actor_user_name,
+             al.action_type,
+             al.entity_type,
+             al.entity_id,
+             al.source_ip,
+             al.metadata,
+             al.event_timestamp
+           FROM Audit_Log al
+           LEFT JOIN User actor
+             ON actor.user_id = al.actor_user_id
+           ${whereClause}
+           ORDER BY al.event_timestamp DESC, al.audit_log_id DESC
+           LIMIT ? OFFSET ?`,
+          [...params, filters.limit, filters.offset]
+        );
+
+        const countRows = await conn.query(
+          `SELECT COUNT(*) AS total_count
+           FROM Audit_Log al
+           ${whereClause}`,
+          params
+        );
+
+        return {
+          rows,
+          total_count: Number(countRows[0]?.total_count || 0),
+        };
+      } finally {
+        if (conn) conn.release();
+      }
+    },
+  };
+}
+
+const AuditLogModel = buildAuditLogModel();
+
+export { buildAuditLogModel };
+export default AuditLogModel;

--- a/models/authorizerModel.js
+++ b/models/authorizerModel.js
@@ -147,7 +147,7 @@ const Authorizer = {
   },
   
   // Decline a travel request
-  async declineTravelRequest(request_id) {
+  async declineTravelRequest(request_id, connection = null) {
     let conn;
     const query = `
       UPDATE Request
@@ -156,7 +156,7 @@ const Authorizer = {
     `;
 
     try {
-      conn = await pool.getConnection();
+      conn = connection || (await pool.getConnection());
       const rows = await conn.query(query, [request_id]);
       return true;
 
@@ -166,7 +166,7 @@ const Authorizer = {
       
     } finally {
       if (conn) {
-        conn.release();
+        if (!connection) conn.release();
       }
     }
   },
@@ -297,7 +297,7 @@ const Authorizer = {
   },
 
   // Update request routing
-  async updateRequestRouting(request_id, assigned_to, authorization_level, status_id = null) {
+  async updateRequestRouting(request_id, assigned_to, authorization_level, status_id = null, connection = null) {
     let conn;
     let query;
     let params;
@@ -319,7 +319,7 @@ const Authorizer = {
     }
 
     try {
-      conn = await pool.getConnection();
+      conn = connection || (await pool.getConnection());
       const result = await conn.query(query, params);
       return result;
 
@@ -328,7 +328,7 @@ const Authorizer = {
       throw error;
 
     } finally {
-      if (conn) conn.release();
+      if (!connection && conn) conn.release();
     }
   },
 

--- a/openapi/audit-log/get-logs.yaml
+++ b/openapi/audit-log/get-logs.yaml
@@ -1,0 +1,110 @@
+paths:
+  /get-logs:
+    get:
+      summary: Get audit logs
+      description: Returns a paginated list of critical action logs. Only accessible by administrators.
+      tags:
+        - Audit Log
+      operationId: getAuditLogs
+      security:
+        - TokenAuth: []
+      parameters:
+        - in: query
+          name: actor_user_id
+          schema:
+            type: integer
+        - in: query
+          name: action_type
+          schema:
+            type: string
+        - in: query
+          name: entity_type
+          schema:
+            type: string
+        - in: query
+          name: entity_id
+          schema:
+            type: string
+        - in: query
+          name: include_metadata
+          schema:
+            type: boolean
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        "200":
+          description: Audit logs returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        audit_log_id:
+                          type: integer
+                        actor_user_id:
+                          type: integer
+                          nullable: true
+                        actor_user_name:
+                          type: string
+                          nullable: true
+                        action_type:
+                          type: string
+                        entity_type:
+                          type: string
+                        entity_id:
+                          type: string
+                          nullable: true
+                        source_ip:
+                          type: string
+                          nullable: true
+                        metadata:
+                          type: object
+                          nullable: true
+                        event_timestamp:
+                          type: string
+                          format: date-time
+                  meta:
+                    type: object
+                    properties:
+                      count:
+                        type: integer
+                      total_count:
+                        type: integer
+                      has_more:
+                        type: boolean
+              example:
+                data:
+                  - audit_log_id: 1
+                    actor_user_id: 21
+                    actor_user_name: admin
+                    action_type: USER_CREATED
+                    entity_type: User
+                    entity_id: "25"
+                    source_ip: "::1"
+                    metadata:
+                      user_name: jdoe
+                      role_id: 2
+                      department_id: 3
+                    event_timestamp: "2026-03-27T18:00:00.000Z"
+                meta:
+                  count: 1
+                  total_count: 1
+                  has_more: false
+        "401":
+          description: Token missing
+        "403":
+          description: Access denied

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "dev": "nodemon index.js",
         "dummy_db": "node ./database/config/dev_db.js dev",
         "empty_db": "node ./database/config/dev_db.js prod",
-        "test": "echo \"No test specified\""
+        "test": "node --test",
+        "test:audit": "node --test tests/auditLog*.test.js"
     },
     "repository": {
         "type": "git",

--- a/routes/auditLogRoutes.js
+++ b/routes/auditLogRoutes.js
@@ -1,0 +1,25 @@
+/**
+ * Audit Log Routes
+ *
+ * Read-only audit endpoints for administrators.
+ */
+
+import express from 'express';
+import auditLogController from '../controllers/auditLogController.js';
+import { authenticateToken, authorizeRole } from '../middleware/auth.js';
+import { validateAuditLogQuery, validateInputs } from '../middleware/validation.js';
+import { generalRateLimiter } from '../middleware/rateLimiters.js';
+
+const router = express.Router();
+
+router.route('/get-logs')
+  .get(
+    generalRateLimiter,
+    authenticateToken,
+    authorizeRole(['Administrador']),
+    validateAuditLogQuery,
+    validateInputs,
+    auditLogController.getAuditLogs
+  );
+
+export default router;

--- a/services/accountsPayableService.js
+++ b/services/accountsPayableService.js
@@ -16,12 +16,12 @@ const AccountsPayableService = {
    * @property {number|null} updatedStatus - The new status ID (6, 8, or null if no change)
    * @property {string} message - Description of the status change
    */
-  async validateReceiptsAndUpdateStatus(requestId) {
+  async validateReceiptsAndUpdateStatus(requestId, options = {}) {
     const statuses = await AccountsPayable.getReceiptStatusesForRequest(requestId);
 
     // If any receipt is rejected, move request back to travel status verification (step 6)
     if (statuses.includes('Rechazado')) {
-      await AccountsPayable.updateRequestStatus(requestId, 6);
+      await AccountsPayable.updateRequestStatus(requestId, 6, options.connection);
       return {
         updatedStatus: 6,
         message: 'Some receipts were rejected. Request moved back to step 6.'
@@ -31,7 +31,7 @@ const AccountsPayableService = {
     // If all receipts are approved, finalize the request (step 8)
     const allApproved = statuses.every(status => status === 'Aprobado');
     if (allApproved) {
-      await AccountsPayable.updateRequestStatus(requestId, 8);
+      await AccountsPayable.updateRequestStatus(requestId, 8, options.connection);
       return {
         updatedStatus: 8,
         message: 'All receipts approved. Request finalized.'

--- a/services/adminService.js
+++ b/services/adminService.js
@@ -74,7 +74,14 @@ export async function createUser(userData) {
     };
     console.log(newUser);
 
-    return await Admin.createUser(newUser);
+    const createdUser = await Admin.createUser(newUser);
+
+    return {
+      user_id: createdUser.user_id,
+      role_id: newUser.role_id,
+      department_id: newUser.department_id,
+      user_name: newUser.user_name,
+    };
   } catch (error) {
     throw new Error(`Error creating user: ${error.message}`);
   }

--- a/services/adminService.js
+++ b/services/adminService.js
@@ -41,7 +41,7 @@ const hash = async (data) => {
  * @param {Object} userData - User data
  * @returns {Promise<Object>} Created user data
  */
-export async function createUser(userData) {
+export async function createUser(userData, options = {}) {
   try {
     const hashedPassword = await hash(userData.password);
 
@@ -74,7 +74,7 @@ export async function createUser(userData) {
     };
     console.log(newUser);
 
-    const createdUser = await Admin.createUser(newUser);
+    const createdUser = await Admin.createUser(newUser, options.connection);
 
     return {
       user_id: createdUser.user_id,
@@ -325,7 +325,7 @@ export async function getUserList() {
  * @param {Object} newUserData - New data for the user
  * @returns {Promise<Object>} Result of the update operation
  */
-export const updateUserData = async (userId, newUserData) => {
+export const updateUserData = async (userId, newUserData, options = {}) => {
     const userData = await User.getUserData(userId);
     if (!userData) {
         throw { status: 404, message: 'No information found for the user' };
@@ -417,7 +417,7 @@ export const updateUserData = async (userId, newUserData) => {
     }
 
     if (Object.keys(fieldsToUpdateInDb).length > 0) {
-        await Admin.updateUser(userId, fieldsToUpdateInDb);
+        await Admin.updateUser(userId, fieldsToUpdateInDb, options.connection);
         return { message: 'User updated successfully', updated_fields: updatedFields };
     }
 

--- a/services/auditLogService.js
+++ b/services/auditLogService.js
@@ -1,0 +1,158 @@
+/**
+ * Audit Log Service
+ *
+ * Provides critical action logging and read-only audit retrieval.
+ */
+
+import AuditLogModel from '../models/auditLogModel.js';
+
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'token',
+  'jwt',
+  'authorization',
+  'cookie',
+  'card',
+  'card_number',
+  'cardnumber',
+  'cvv',
+  'pan',
+  'email',
+  'phone',
+  'phone_number',
+]);
+
+function sanitizeAuditMetadata(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeAuditMetadata(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce((acc, [key, nestedValue]) => {
+      if (!SENSITIVE_KEYS.has(String(key).toLowerCase())) {
+        acc[key] = sanitizeAuditMetadata(nestedValue);
+      }
+      return acc;
+    }, {});
+  }
+
+  return value;
+}
+
+function parseMetadata(value) {
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function getClientIp(req) {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.trim()) {
+    return forwardedFor.split(',')[0].trim().slice(0, 45);
+  }
+
+  return req.ip ? String(req.ip).slice(0, 45) : null;
+}
+
+function normalizeBoolean(value, defaultValue) {
+  if (value === undefined) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    return value.toLowerCase() === 'true';
+  }
+  return Boolean(value);
+}
+
+function normalizeAuditLogFilters(rawFilters = {}) {
+  return {
+    actor_user_id:
+      rawFilters.actor_user_id === undefined || rawFilters.actor_user_id === null
+        ? null
+        : Number(rawFilters.actor_user_id),
+    action_type: rawFilters.action_type ? String(rawFilters.action_type).trim() : null,
+    entity_type: rawFilters.entity_type ? String(rawFilters.entity_type).trim() : null,
+    entity_id: rawFilters.entity_id ? String(rawFilters.entity_id).trim() : null,
+    limit: rawFilters.limit === undefined ? 50 : Number(rawFilters.limit),
+    offset: rawFilters.offset === undefined ? 0 : Number(rawFilters.offset),
+    include_metadata: normalizeBoolean(rawFilters.include_metadata, true),
+  };
+}
+
+function buildAuditLogService({ auditLogModel = AuditLogModel } = {}) {
+  return {
+    async recordAuditLog({
+      actorUserId = null,
+      actionType,
+      entityType,
+      entityId = null,
+      sourceIp = null,
+      metadata = null,
+    }) {
+      const sanitizedMetadata = metadata ? sanitizeAuditMetadata(metadata) : null;
+
+      return auditLogModel.createAuditLog({
+        actor_user_id: actorUserId,
+        action_type: actionType,
+        entity_type: entityType,
+        entity_id: entityId === null || entityId === undefined ? null : String(entityId),
+        source_ip: sourceIp ? String(sourceIp).slice(0, 45) : null,
+        metadata: sanitizedMetadata ? JSON.stringify(sanitizedMetadata) : null,
+      });
+    },
+
+    async recordAuditLogFromRequest(req, event) {
+      try {
+        return await this.recordAuditLog({
+          actorUserId: req.user?.user_id ?? null,
+          sourceIp: getClientIp(req),
+          ...event,
+        });
+      } catch (error) {
+        console.error('Audit log write failed:', error);
+        return null;
+      }
+    },
+
+    async getAuditLogs(rawFilters = {}) {
+      const filters = normalizeAuditLogFilters(rawFilters);
+      const result = await auditLogModel.getAuditLogs(filters);
+      const data = result.rows.map((row) => ({
+        audit_log_id: row.audit_log_id,
+        actor_user_id: row.actor_user_id,
+        actor_user_name: row.actor_user_name || null,
+        action_type: row.action_type,
+        entity_type: row.entity_type,
+        entity_id: row.entity_id,
+        source_ip: row.source_ip,
+        metadata: filters.include_metadata ? parseMetadata(row.metadata) : null,
+        event_timestamp: row.event_timestamp
+          ? new Date(row.event_timestamp).toISOString()
+          : null,
+      }));
+
+      return {
+        data,
+        meta: {
+          count: data.length,
+          total_count: result.total_count,
+          has_more: filters.offset + data.length < result.total_count,
+          filters,
+        },
+      };
+    },
+  };
+}
+
+const AuditLogService = buildAuditLogService();
+
+export {
+  buildAuditLogService,
+  getClientIp,
+  normalizeAuditLogFilters,
+  sanitizeAuditMetadata,
+};
+export default AuditLogService;

--- a/services/auditLogService.js
+++ b/services/auditLogService.js
@@ -91,7 +91,7 @@ function buildAuditLogService({ auditLogModel = AuditLogModel } = {}) {
       entityId = null,
       sourceIp = null,
       metadata = null,
-    }) {
+    }, options = {}) {
       const sanitizedMetadata = metadata ? sanitizeAuditMetadata(metadata) : null;
 
       return auditLogModel.createAuditLog({
@@ -101,20 +101,15 @@ function buildAuditLogService({ auditLogModel = AuditLogModel } = {}) {
         entity_id: entityId === null || entityId === undefined ? null : String(entityId),
         source_ip: sourceIp ? String(sourceIp).slice(0, 45) : null,
         metadata: sanitizedMetadata ? JSON.stringify(sanitizedMetadata) : null,
-      });
+      }, options.connection);
     },
 
-    async recordAuditLogFromRequest(req, event) {
-      try {
-        return await this.recordAuditLog({
-          actorUserId: req.user?.user_id ?? null,
-          sourceIp: getClientIp(req),
-          ...event,
-        });
-      } catch (error) {
-        console.error('Audit log write failed:', error);
-        return null;
-      }
+    async recordAuditLogFromRequest(req, event, options = {}) {
+      return this.recordAuditLog({
+        actorUserId: req.user?.user_id ?? null,
+        sourceIp: getClientIp(req),
+        ...event,
+      }, options);
     },
 
     async getAuditLogs(rawFilters = {}) {

--- a/services/authorizerService.js
+++ b/services/authorizerService.js
@@ -107,6 +107,7 @@ const authorizeRequest = async (request_id, user_id) => {
       message: "Request authorized successfully",
       new_assigned_to: new_assigned_to,
       new_authorization_level: new_authorization_level,
+      new_status: new_status_id,
       escalated_to_boss: authorizerUser.boss_id ? true : false,
       completed_all_authorizations: new_authorization_level >= AUTHORIZATION_LEVELS,
       status_advanced: true

--- a/services/authorizerService.js
+++ b/services/authorizerService.js
@@ -28,7 +28,7 @@ import { AUTHORIZATION_LEVELS } from "../config/constants.js";
  * @returns {object} An object with authorization result
  * @throws Will throw an error if validation fails
  */
-const authorizeRequest = async (request_id, user_id) => {
+const authorizeRequest = async (request_id, user_id, options = {}) => {
   try {
     // Get request details
     const request = await Authorizer.getRequestWithDetails(request_id);
@@ -100,7 +100,8 @@ const authorizeRequest = async (request_id, user_id) => {
       request_id, 
       new_assigned_to, 
       new_authorization_level, 
-      new_status_id
+      new_status_id,
+      options.connection
     );
 
     return {
@@ -128,7 +129,7 @@ const authorizeRequest = async (request_id, user_id) => {
  * @returns {object} An object with decline confirmation
  * @throws Will throw an error if validation fails
  */
-const declineRequest = async (request_id, user_id) => {
+const declineRequest = async (request_id, user_id, options = {}) => {
   try {
     // Get request details
     const request = await Authorizer.getRequestWithDetails(request_id);
@@ -145,7 +146,7 @@ const declineRequest = async (request_id, user_id) => {
     }
 
     // Decline the request (set to status 10: Rechazado)
-    await Authorizer.declineTravelRequest(request_id);
+    await Authorizer.declineTravelRequest(request_id, options.connection);
 
     return {
       message: "Request declined successfully",

--- a/tests/auditLogService.test.js
+++ b/tests/auditLogService.test.js
@@ -96,3 +96,32 @@ test('recordAuditLogFromRequest uses authenticated user and sanitized metadata',
     user_name: 'jdoe',
   });
 });
+
+test('recordAuditLogFromRequest propagates audit write failures', async () => {
+  const service = buildAuditLogService({
+    auditLogModel: {
+      async createAuditLog() {
+        throw new Error('write failed');
+      },
+      async getAuditLogs() {
+        return { rows: [], total_count: 0 };
+      },
+    },
+  });
+
+  await assert.rejects(
+    service.recordAuditLogFromRequest(
+      {
+        user: { user_id: 5 },
+        headers: {},
+        ip: '127.0.0.1',
+      },
+      {
+        actionType: 'USER_UPDATED',
+        entityType: 'User',
+        entityId: 9,
+      }
+    ),
+    /write failed/
+  );
+});

--- a/tests/auditLogService.test.js
+++ b/tests/auditLogService.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test, { after } from 'node:test';
+
+import pool from '../database/config/db.js';
+import {
+  buildAuditLogService,
+  getClientIp,
+  normalizeAuditLogFilters,
+  sanitizeAuditMetadata,
+} from '../services/auditLogService.js';
+
+after(async () => {
+  await pool.end();
+});
+
+test('sanitizeAuditMetadata removes sensitive keys recursively', () => {
+  const sanitized = sanitizeAuditMetadata({
+    email: 'hidden@example.com',
+    password: 'secret',
+    nested: {
+      phone_number: '555-0000',
+      safe: true,
+    },
+    array: [
+      { token: 'jwt', safe: 'ok' },
+    ],
+  });
+
+  assert.deepEqual(sanitized, {
+    nested: {
+      safe: true,
+    },
+    array: [
+      { safe: 'ok' },
+    ],
+  });
+});
+
+test('normalizeAuditLogFilters applies stable defaults', () => {
+  assert.deepEqual(normalizeAuditLogFilters({}), {
+    actor_user_id: null,
+    action_type: null,
+    entity_type: null,
+    entity_id: null,
+    limit: 50,
+    offset: 0,
+    include_metadata: true,
+  });
+});
+
+test('getClientIp prefers first forwarded IP and truncates safely', () => {
+  const ip = getClientIp({
+    headers: { 'x-forwarded-for': '10.0.0.1, 127.0.0.1' },
+    ip: '::1',
+  });
+
+  assert.equal(ip, '10.0.0.1');
+});
+
+test('recordAuditLogFromRequest uses authenticated user and sanitized metadata', async () => {
+  let capturedEntry = null;
+  const service = buildAuditLogService({
+    auditLogModel: {
+      async createAuditLog(entry) {
+        capturedEntry = entry;
+        return { audit_log_id: 1 };
+      },
+      async getAuditLogs() {
+        return { rows: [], total_count: 0 };
+      },
+    },
+  });
+
+  const result = await service.recordAuditLogFromRequest(
+    {
+      user: { user_id: 21 },
+      headers: {},
+      ip: '::1',
+    },
+    {
+      actionType: 'USER_CREATED',
+      entityType: 'User',
+      entityId: 25,
+      metadata: {
+        user_name: 'jdoe',
+        email: 'hidden@example.com',
+      },
+    }
+  );
+
+  assert.equal(result.audit_log_id, 1);
+  assert.equal(capturedEntry.actor_user_id, 21);
+  assert.equal(capturedEntry.source_ip, '::1');
+  assert.equal(capturedEntry.entity_id, '25');
+  assert.deepEqual(JSON.parse(capturedEntry.metadata), {
+    user_name: 'jdoe',
+  });
+});


### PR DESCRIPTION
## Summary
- add the backend audit log foundation with schema, model, service, controller, routes, and OpenAPI documentation
- integrate audit logging into critical successful mutations across admin, authorizer, and accounts payable flows
- enforce transactional audit writes for those critical mutations so audit insert failures roll back the business write instead of being silently swallowed
- add an admin-only audit log query endpoint and audit service tests

## What changed
- created the `Audit_Log` table and migration patch
- added reusable audit logging data access and service logic with metadata sanitization
- mounted `GET /api/audit-log/get-logs` for admin-only read access
- logged successful critical actions for user create/update/deactivate, request approval/decline, request quotation, receipt validation, and request receipt validation
- moved the audited mutation paths onto explicit DB transactions
- removed silent swallowing of audit insert failures

## Verification
- `pnpm test:audit`
- `pnpm test`
- imported the touched controllers/services successfully with Node ESM import checks
- previously smoke tested create/deactivate user and audit log retrieval on the local API

## Notes
- bulk CSV user import is intentionally not part of the strict transactional audit guarantee in this PR
- local `.env` and `pnpm-lock.yaml` changes were not included

Closes #132
Closes #137
Closes #143
Refs #142
