### PR TITLE
[Chore] Soft deletion of societies and society groups, revision of emails for permissions, and avoid returning the same user twice for auth rules 

### DIFF
--- a/controllers/accountabilityController.js
+++ b/controllers/accountabilityController.js
@@ -67,7 +67,7 @@ const buildAnticipo = (request, accountsCatalog, documentMap) => {
 
   // Get currency and exchange rate
   const currency = firstReceipt?.xml_moneda || firstReceipt?.currency || society?.local_currency;
-  const amount = request.requested_fee || 0;
+  const amount = request.imposed_fee || 0;
 
   const isSameCurrency = currency === society?.local_currency;
   const exchRate = isSameCurrency ? 1.0 : parseFloat((firstReceipt?.exch_rate || 0).toFixed(2));
@@ -258,11 +258,17 @@ const buildSinAnticipo = (request, accountsCatalog, documentMap) => {
  */
 export const exportAllPolicies = async (req, res) => {
   try {
-    // Fetch all three policy types in parallel
+    const societyGroupId = req.user?.society_group_id;
+
+    if (!societyGroupId) {
+      return res.status(400).json({ error: 'User does not belong to a society group' });
+    }
+
+    // Fetch all three policy types in parallel, filtered by society group
     const [rawAnticipos, rawComprobaciones, rawSinAnticipo, accounts, documents] = await Promise.all([
-      Accountability.getAnticipoPolicies(),
-      Accountability.getComprobacionPolicies(),
-      Accountability.getSinAnticipoPolicies(),
+      Accountability.getAnticipoPolicies(societyGroupId),
+      Accountability.getComprobacionPolicies(societyGroupId),
+      Accountability.getSinAnticipoPolicies(societyGroupId),
       Accountability.getAccounts(),
       Accountability.getDocuments(),
     ]);

--- a/controllers/auditLogController.js
+++ b/controllers/auditLogController.js
@@ -13,12 +13,18 @@ export async function getAuditLogs(req, res) {
       : [];
     const canViewByGroup = permissionKeys.includes('superadmin:view_group_audit_log') || req.user?.role === 'Superadministrador';
 
-    const requestedGroupId = req.query?.society_group_id ? Number(req.query.society_group_id) : null;
+    let society_group_id = null;
+    if (canViewByGroup && req.query?.society_group_id) {
+      // If the user has permission and provided a society_group_id, use it
+      society_group_id = Number(req.query.society_group_id);
+    } else if (!canViewByGroup) {
+      // If the user doesn't have permission, restrict to their own group
+      society_group_id = req.user?.society_group_id ?? null;
+    }
+
     const scopedFilters = {
       ...req.query,
-      society_group_id: canViewByGroup
-        ? requestedGroupId ?? req.user?.society_group_id ?? null
-        : req.user?.society_group_id ?? null,
+      society_group_id,
     };
 
     const response = await AuditLogService.getAuditLogs(scopedFilters);

--- a/controllers/requestController.js
+++ b/controllers/requestController.js
@@ -9,10 +9,10 @@ import RequestService from '../services/requestService.js';
 export const getUserRequests = async (req, res) => {
   const userId = Number(req.params.user_id);
   const societyId = Number(req.user.society_id);
-  const { status, sort = 'desc' } = req.query;
+  const { status, sort = 'desc', assignedOnly } = req.query;
 
   try {
-    const requests = await RequestService.getUserRequests(userId, societyId, { status, sort });
+    const requests = await RequestService.getUserRequests(userId, societyId, { status, sort, assignedOnly: assignedOnly === 'true' });
     return res.status(200).json(requests);
   } catch (err) {
     console.error('Error in getUserRequests controller:', err);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -157,6 +157,14 @@ export const getTravelRequestById = async (req, res) => {
 
     // Extract base data and decrypt sensitive information
     const base = requestData[0];
+
+    // Validate user authorization: can only view own requests, assigned requests, or as admin
+    const isCreator = base.user_id === req.user.user_id;
+    const isAssigned = base.assigned_to === req.user.user_id;
+
+    if (!isCreator && !isAssigned && !isAdmin) {
+      return res.status(403).json({ error: "Forbidden: You don't have permission to view this request" });
+    }
     const decryptedEmail = decrypt(base.user_email);
     const decryptedPhone = decrypt(base.user_phone_number);
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -179,6 +179,8 @@ export const getTravelRequestById = async (req, res) => {
       creation_date: formatDate(base.creation_date),
       currency: base.currency || 'MXN',
       exch_rate: base.exch_rate,
+      authorization_level: base.authorization_level,
+      authorization_levels_total: base.authorization_levels_total,
       user: {
         user_name: base.user_name,
         user_email: decryptedEmail,

--- a/middleware/rateLimiters.js
+++ b/middleware/rateLimiters.js
@@ -18,7 +18,7 @@ export var generalRateLimiter = RateLimit({
 // Rate limiter specifically for login attempts
 export var loginRateLimiter = RateLimit({
     windowMs: 1 * 60 * 1000, // 1 minute
-    max: 5, // Limit each IP to 5 login attempts per windowMs
+    max: 20, // Limit each IP login attempts per windowMs
     message: 'Too many login attempts from this IP, please try again after a minute',
 });
 

--- a/models/accountabilityModel.js
+++ b/models/accountabilityModel.js
@@ -22,18 +22,23 @@ const Accountability = {
    *
    * A Request qualifies as an anticipo when:
    *   - active = true
-   *   - requested_fee > 0  (has an advance payment)
+   *   - imposed_fee > 0  (has an advance payment)
    *   - Event: 'advance_given' (anticipo fue otorgado)
-   *   - NO tiene receipts validados (those go to comprobacion instead)
+   *   - Does not have validated receipts (those go to comprobacion instead)
    *   - IS_EXPORTED = false
+   *   - Belongs to the specified society group
    *
+   * @param {number} societyGroupId - Filter by society group
    * @returns {Promise<Array>}
    */
-  async getAnticipoPolicies() {
+  async getAnticipoPolicies(societyGroupId) {
     try {
       const where = {
         active: true,
-        requested_fee: { gt: 0 },
+        imposed_fee: { gt: 0 },
+        Society: {
+          society_group_id: societyGroupId,
+        },
 
         // [IS_EXPORTED]
         NOT: {
@@ -117,18 +122,23 @@ const Accountability = {
    *
    * A Request qualifies when:
    *   - active = true
-   *   - requested_fee > 0 (had an advance)
+   *   - imposed_fee > 0 (had an advance)
    *   - Has validated receipts (comprobación)
    *   - Event: 'receipt_uploaded'
    *   - IS_EXPORTED = false
+   *   - Belongs to the specified society group
    *
+   * @param {number} societyGroupId - Filter by society group
    * @returns {Promise<Array>}
    */
-  async getComprobacionPolicies() {
+  async getComprobacionPolicies(societyGroupId) {
     try {
       const where = {
         active: true,
-        requested_fee: { gt: 0 },
+        imposed_fee: { gt: 0 },
+        Society: {
+          society_group_id: societyGroupId,
+        },
         Receipt: {
           some: {
             validation: 'Aprobado',
@@ -220,21 +230,26 @@ const Accountability = {
    *
    * A Request qualifies when:
    *   - active = true
-   *   - requested_fee = 0 or null (no advance)
+   *   - imposed_fee = 0 or null (no advance assigned)
    *   - Has validated receipts
    *   - Event: 'receipt_uploaded'
    *   - IS_EXPORTED = false
+   *   - Belongs to the specified society group
    *
+   * @param {number} societyGroupId - Filter by society group
    * @returns {Promise<Array>}
    */
-  async getSinAnticipoPolicies() {
+  async getSinAnticipoPolicies(societyGroupId) {
     try {
       const where = {
         active: true,
         OR: [
-          { requested_fee: 0 },
-          { requested_fee: null },
+          { imposed_fee: 0 },
+          { imposed_fee: null },
         ],
+        Society: {
+          society_group_id: societyGroupId,
+        },
         Receipt: {
           some: {
             validation: 'Aprobado',

--- a/models/adminModel.js
+++ b/models/adminModel.js
@@ -868,10 +868,10 @@ const Admin = {
     }
   },
 
-  // Get auth rules
+  // Get active auth rules
   async getAuthRules(societyId = null) {
     try {
-      const where = {};
+      const where = { active: true };
 
       if (societyId) {
         where.OR = [
@@ -1009,7 +1009,8 @@ const Admin = {
     }
   },
 
-  // Delete auth rule
+  // Deactivate auth rule (soft delete)
+  // Rule is hidden from new requests but remains for existing ones using it
   async deleteAuthRule(ruleId, societyId = null) {
     try {
       const id = Number(ruleId);
@@ -1023,29 +1024,19 @@ const Admin = {
         if (rule && rule.society_id && rule.society_id !== Number(societyId)) {
           throw new Error('Unauthorized: Rule does not belong to your society');
         }
-
-        const requestCountOutsideSociety = await prisma.request.count({
-          where: {
-            authorization_rule_id: id,
-            society_id: {
-              not: Number(societyId),
-            },
-          },
-        });
-
-        if (requestCountOutsideSociety > 0) {
-          throw new Error('Unauthorized: Rule is used by another society');
-        }
       }
 
-      // Step 1: Delete all levels associated with the rule
-      await prisma.authorizationRuleLevel.deleteMany({ where: { rule_id: id } });
-      // Step 2: Delete the rule itself
-      await prisma.authorizationRule.delete({ where: { rule_id: id } });
-      console.log(`Auth rule with ID ${ruleId} and its associated levels have been deleted.`);
+      // Deactivate the rule instead of deleting
+      // Levels remain unchanged so existing requests continue to work
+      await prisma.authorizationRule.update({
+        where: { rule_id: id },
+        data: { active: false }
+      });
+      
+      console.log(`Auth rule with ID ${ruleId} has been deactivated.`);
       return true;
     } catch (error) {
-      console.error('Error deleting auth rule:', error);
+      console.error('Error deactivating auth rule:', error);
       throw error;
     }
   },

--- a/models/adminModel.js
+++ b/models/adminModel.js
@@ -469,15 +469,15 @@ const Admin = {
     }
   },
 
-  // Get roles with their permissions
+  // Get active roles with their permissions
   async getRoles(societyId = null, requester = null) {
     try {
-      const where = societyId ? { society_id: Number(societyId) } : {};
+      const where = { active: true };
 
       if (societyId) {
         where.OR = [
-          { society_id: Number(societyId) },
-          { society_id: null },
+          { society_id: Number(societyId), active: true },
+          { society_id: null, active: true },
         ];
       }
 
@@ -532,7 +532,7 @@ const Admin = {
       },
     });
 
-    if (!role) return null;
+    if (!role || !role.active) return null;
 
     if (role.role_name === SUPERADMIN_ROLE_NAME) {
       throw new Error('Unauthorized: Role is restricted');
@@ -560,8 +560,8 @@ const Admin = {
 
   async getDefaultRole(societyId = null, requester = null) {
     const where = societyId
-      ? { society_id: Number(societyId), is_default: true }
-      : { is_default: true };
+      ? { society_id: Number(societyId), is_default: true, active: true }
+      : { is_default: true, active: true };
 
     where.role_name = { not: SUPERADMIN_ROLE_NAME };
 
@@ -575,7 +575,7 @@ const Admin = {
             },
           },
         },
-        { is_default: true },
+        { is_default: true, active: true },
       ];
     }
 
@@ -598,8 +598,8 @@ const Admin = {
     }
 
     const fallbackWhere = societyId
-      ? { society_id: Number(societyId), role_name: 'Solicitante' }
-      : { role_name: 'Solicitante' };
+      ? { society_id: Number(societyId), role_name: 'Solicitante', active: true }
+      : { role_name: 'Solicitante', active: true };
 
     const fallback = await prisma.role.findFirst({
       where: fallbackWhere,
@@ -631,10 +631,11 @@ const Admin = {
         role_name: true,
         is_system: true,
         society_id: true,
+        active: true,
       },
     });
 
-    if (!role) {
+    if (!role || !role.active) {
       return false;
     }
 
@@ -826,13 +827,13 @@ const Admin = {
       }
     }
 
-    const assignedUsers = await prisma.user.count({ where: { role_id: id, active: true } });
-    if (assignedUsers > 0) {
-      throw new Error('Cannot delete role: there are active users assigned to this role');
-    }
-
-    await prisma.role_Permission.deleteMany({ where: { role_id: id } });
-    await prisma.role.delete({ where: { role_id: id } });
+    // Soft delete role by marking it as inactive
+    // Users assigned to this role will keep it,
+    // but the role won't be available for new assignments
+    await prisma.role.update({
+      where: { role_id: id },
+      data: { active: false },
+    });
 
     return true;
   },

--- a/models/authorizationRuleModel.js
+++ b/models/authorizationRuleModel.js
@@ -8,10 +8,11 @@
 import { prisma } from '../lib/prisma.js';
 
 const AuthorizationRuleModel = {
-  // Get all authorization rules
+  // Get all active authorization rules
   async getAllRules() {
     try {
       return await prisma.authorizationRule.findMany({
+        where: { active: true },
         orderBy: [
           { is_default: 'asc' },
           { rule_id: 'asc' },
@@ -47,12 +48,13 @@ const AuthorizationRuleModel = {
   },
 
   // Get rules that match travel type, duration, and amount criteria
-  // Returns all rules that could potentially apply
+  // Returns all active rules that could potentially apply
   async getRulesByCriteria(travelType, duration, amount, societyId) {
     try {
       // Build dynamic Prisma where clause
       const where = {
         AND: [
+          { active: true },
           {
             OR: [
               { society_id: Number(societyId) },
@@ -114,12 +116,13 @@ const AuthorizationRuleModel = {
     }
   },
 
-  // Get default authorization rule
+  // Get default active authorization rule
   async getDefaultRule(societyId) {
     try {
       const rule = await prisma.authorizationRule.findFirst({
         where: {
           is_default: true,
+          active: true,
           society_id: Number(societyId)
         },
         orderBy: { rule_id: 'asc' },

--- a/models/requestModel.js
+++ b/models/requestModel.js
@@ -11,18 +11,19 @@ const RequestModel = {
    * Get requests visible to a user (requester OR assignee)
    * @param {number} userId - User ID
    * @param {number} societyId - Society ID for access control
-   * @param {Object} filters - Optional filters: { status, sort }
+   * @param {Object} filters - Optional filters: { status, sort, assignedOnly }
    * @returns {Promise<Array>} Formatted requests array
    */
-  async getUserRequests(userId, societyId, { status, sort = 'desc' } = {}) {
+  async getUserRequests(userId, societyId, { status, sort = 'desc', assignedOnly = false } = {}) {
     const requests = await prisma.request.findMany({
       where: {
-        OR: [
-          { user_id: Number(userId) },
-        ],
+        ...(assignedOnly
+          ? { assigned_to: Number(userId) }
+          : { user_id: Number(userId) }
+        ),
         society_id: Number(societyId),
         active: true,
-        ...(status ? { Request_status: { status } } : {}),
+        ...(status ? { Request_status: { is: { status } } } : {}),
       },
       orderBy: { creation_date: sort },
       select: {
@@ -40,7 +41,6 @@ const RequestModel = {
           select: { user_name: true }
         },
         Route_Request: {
-          take: 1,
           include: {
             Route: {
               select: {

--- a/models/requestModel.js
+++ b/models/requestModel.js
@@ -22,7 +22,11 @@ const RequestModel = {
           : { user_id: Number(userId) }
         ),
         society_id: Number(societyId),
-        active: true,
+        OR: [
+          { active: true },
+          { Request_status: { is: { status: 'Rechazado' } } },
+          { Request_status: { is: { status: 'Cancelado' } } },
+        ],
         ...(status ? { Request_status: { is: { status } } } : {}),
       },
       orderBy: { creation_date: sort },
@@ -34,8 +38,12 @@ const RequestModel = {
         imposed_fee: true,
         request_days: true,
         creation_date: true,
+        authorization_level: true,
         Request_status: {
           select: { status: true }
+        },
+        AuthorizationRule: {
+          select: { num_levels: true }
         },
         assignedUser: {
           select: { user_name: true }
@@ -66,6 +74,8 @@ const RequestModel = {
       imposed_fee: req.imposed_fee || 0,
       request_days: req.request_days || 0,
       creation_date: req.creation_date,
+      authorization_level: req.authorization_level ?? 0,
+      authorization_levels_total: req.AuthorizationRule?.num_levels ?? null,
       assigned_to_name: req.assignedUser?.user_name || undefined,
       routes: req.Route_Request.map(rr => ({
         route_id: rr.Route.route_id,

--- a/models/societyGroupModel.js
+++ b/models/societyGroupModel.js
@@ -8,14 +8,23 @@ import { prisma } from '../lib/prisma.js';
 
 export async function getSocietyGroups() {
   return await prisma.societyGroup.findMany({
-    include: { Society: true }
+    where: { active: true },
+    include: {
+      Society: {
+        where: { active: true }
+      }
+    }
   });
 }
 
 export async function getSocietyGroupById(groupId) {
   return await prisma.societyGroup.findUnique({
     where: { id: groupId },
-    include: { Society: true }
+    include: {
+      Society: {
+        where: { active: true }
+      }
+    }
   });
 }
 
@@ -39,8 +48,16 @@ export async function updateSocietyGroup(groupId, data) {
 }
 
 export async function deleteSocietyGroup(groupId) {
-  await prisma.societyGroup.delete({
-    where: { id: groupId }
+  // Deactivate all societies in the group
+  await prisma.society.updateMany({
+    where: { society_group_id: groupId },
+    data: { active: false }
+  });
+
+  // Deactivate the group
+  return await prisma.societyGroup.update({
+    where: { id: groupId },
+    data: { active: false }
   });
 }
 

--- a/models/societyModel.js
+++ b/models/societyModel.js
@@ -8,7 +8,10 @@ import { prisma } from '../lib/prisma.js';
 
 export async function getSocieties(societyGroupId) {
   return await prisma.society.findMany({
-    where: societyGroupId ? { society_group_id: societyGroupId } : undefined,
+    where: {
+      active: true,
+      ...(societyGroupId && { society_group_id: societyGroupId })
+    },
     include: {
       SocietyGroup: true,
     }
@@ -27,6 +30,7 @@ export async function getSocietyById(societyId) {
 export async function getSocietyByNameAndGroup(description, societyGroupId) {
   return await prisma.society.findFirst({
     where: {
+      active: true,
       description: description,
       society_group_id: societyGroupId
     },
@@ -64,8 +68,9 @@ export async function updateSociety(societyId, data) {
 }
 
 export async function deleteSociety(societyId) {
-  return await prisma.society.delete({
-    where: { id: societyId }
+  return await prisma.society.update({
+    where: { id: societyId },
+    data: { active: false }
   });
 }
 

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -53,6 +53,31 @@ const User = {
     };
   },
 
+  async getUserPermissions(userId) {
+    try {
+      const user = await prisma.user.findUnique({
+        where: { user_id: Number(userId) },
+        include: {
+          role: {
+            include: {
+              Role_Permission: {
+                include: {
+                  Permission: {
+                    select: { permission_key: true }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+      return user?.role?.Role_Permission?.map(rp => rp.Permission.permission_key) || [];
+    } catch (error) {
+      console.error('Error fetching user permissions:', error);
+      return [];
+    }
+  },
+
   async getTravelRequestById(requestId) {
     const request = await prisma.request.findUnique({
       where: { request_id: Number(requestId) },

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -84,6 +84,8 @@ const User = {
 
     const base = {
       request_id: request.request_id,
+      user_id: request.user_id,
+      assigned_to: request.assigned_to,
       request_status: request.Request_status?.status ?? null,
       notes: request.notes,
       requested_fee: request.requested_fee,

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -90,6 +90,9 @@ const User = {
             phone_number: true,
           },
         },
+        AuthorizationRule: {
+          select: { num_levels: true }
+        },
         Route_Request: {
           include: {
             Route: {
@@ -122,6 +125,8 @@ const User = {
       user_name: request.requester?.user_name ?? null,
       user_email: request.requester?.email ?? null,
       user_phone_number: request.requester?.phone_number ?? null,
+      authorization_level: request.authorization_level ?? 0,
+      authorization_levels_total: request.AuthorizationRule?.num_levels ?? null,
     };
 
     const routeRows = request.Route_Request
@@ -226,6 +231,7 @@ const User = {
         beginning_date: route?.beginning_date ?? null,
         ending_date: route?.ending_date ?? null,
         request_status: req.Request_status?.status ?? null,
+        authorization_level: req.authorization_level ?? 0,
         assigned_to_name: req.assignedUser?.user_name ?? null,
       };
     });

--- a/prisma/dummyData.js
+++ b/prisma/dummyData.js
@@ -385,17 +385,6 @@ export const REQUESTS = [
     exch_rate: 0,
   },
   {
-    notes: 'Reembolso por gastos medicos durante viaje.',
-    requested_fee: 0,
-    imposed_fee: 0,
-    request_days: 1.0,
-    status: 'Revisión',
-    assigned_to_username: 'diego.hernandez',
-    document_id: 'GV',
-    authorization_rule_id: 1,
-    exch_rate: 0,
-  },
-  {
     notes: 'Solicitud de apoyo economico para capacitacion online.',
     requested_fee: 500.0,
     imposed_fee: 500.0,

--- a/prisma/migrations/20260501174535_add_active_to_society_and_group/migration.sql
+++ b/prisma/migrations/20260501174535_add_active_to_society_and_group/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `Society` ADD COLUMN `active` BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE `SocietyGroup` ADD COLUMN `active` BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20260503032238_add_active_auth_rules/migration.sql
+++ b/prisma/migrations/20260503032238_add_active_auth_rules/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `AuthorizationRule` ADD COLUMN `active` BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model AuthorizationRule {
   max_duration Int?
   min_amount   Float?                         @db.Float
   max_amount   Float?                         @db.Float
+  active       Boolean                        @default(true)
   society_id   Int?
   Society      Society?                       @relation(fields: [society_id], references: [id])
   levels       AuthorizationRuleLevel[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -391,6 +391,7 @@ model SocietyGroup {
   id          Int       @id @default(autoincrement())
   description String?   @db.VarChar(255)
   is_default  Boolean   @default(false)
+  active      Boolean   @default(true)
   Society     Society[]
 }
 
@@ -401,6 +402,7 @@ model Society {
   local_currency    String              @db.VarChar(6)
   society_group_id  Int?
   is_default        Boolean             @default(false)
+  active            Boolean             @default(true)
   SocietyGroup      SocietyGroup?       @relation(fields: [society_group_id], references: [id])
   User              User[]
   Request           Request[]

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -47,38 +47,7 @@ async function seedDefaultSocietyGroupAndSociety() {
   }
 }
 
-/**
- * Create default authorization rule for the default society
- */
-async function seedDefaultAuthRule(defaultSocietyId) {
-  await prisma.authorizationRule.create({
-    data: {
-      rule_name: 'Regla por Defecto',
-      is_default: true,
-      num_levels: 2,
-      automatic: true,
-      travel_type: 'Todos',
-      society_id: defaultSocietyId,
-    },
-  });
-}
 
-/**
- * Create default refund policy for the default society
- */
-async function seedDefaultRefundPolicy(defaultSocietyId) {
-  await prisma.refundPolicy.create({
-    data: {
-      policy_name: 'Política por Defecto',
-      min_amount: 10,
-      max_amount: 5000,
-      submission_deadline_days: 30,
-      society_id: defaultSocietyId,
-      is_default: true,
-      active: true,
-    },
-  });
-}
 
 /**
  * Seed the database with base data
@@ -92,8 +61,6 @@ export async function seedBaseData() {
   } = await seedDefaultSocietyGroupAndSociety();
   await seedReferenceData(prisma, defaultSocietyId);
   await seedCountriesAndCities(prisma);
-  await seedDefaultAuthRule(defaultSocietyId);
-  await seedDefaultRefundPolicy(defaultSocietyId);
   await seedCurrencies(prisma);
   await seedAdmin(prisma, defaultSocietyId);
   await seedSuperadmin(prisma, defaultSocietyId);

--- a/prisma/seedShared.js
+++ b/prisma/seedShared.js
@@ -206,21 +206,26 @@ export async function seedReferenceData(prisma, defaultSocietyId) {
     }
   }
 
-  await upsertOrderedRecords(prisma.request_status, [
-    { status: 'Borrador' },
-    { status: 'Revisión' },
-    { status: 'Cotización del Viaje' },
-    { status: 'Atención Agencia de Viajes' },
-    { status: 'Comprobación gastos del viaje' },
-    { status: 'Validación de comprobantes' },
-    { status: 'Finalizado' },
-    { status: 'Cancelado' },
-    { status: 'Rechazado' },
-  ], (item) => ({
-    where: { status: item.status },
-    create: { status: item.status },
-    update: { status: item.status },
-  }));
+  // Create request statuses with fixed IDs
+  const statuses = [
+    { request_status_id: 1, status: 'Borrador' },
+    { request_status_id: 2, status: 'Revisión' },
+    { request_status_id: 3, status: 'Cotización del Viaje' },
+    { request_status_id: 4, status: 'Atención Agencia de Viajes' },
+    { request_status_id: 5, status: 'Comprobación gastos del viaje' },
+    { request_status_id: 6, status: 'Validación de comprobantes' },
+    { request_status_id: 7, status: 'Finalizado' },
+    { request_status_id: 8, status: 'Cancelado' },
+    { request_status_id: 9, status: 'Rechazado' },
+  ];
+
+  for (const status of statuses) {
+    await prisma.request_status.upsert({
+      where: { status: status.status },
+      create: { request_status_id: status.request_status_id, status: status.status },
+      update: { status: status.status },
+    });
+  }
 
   await upsertOrderedRecords(prisma.receipt_Type, [
     { receipt_type_name: 'Hospedaje' },

--- a/routes/exchangeRateRoutes.js
+++ b/routes/exchangeRateRoutes.js
@@ -12,11 +12,12 @@
 
 import express from 'express';
 import * as exchangeRateController from '../controllers/exchangeRateController.js';
+import { authenticateToken } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.get('/catalog', exchangeRateController.getCatalog);
-router.get('/', exchangeRateController.getCurrentExchangeRate);
-router.post('/clear-cache', exchangeRateController.clearCache);
+router.get('/catalog', authenticateToken, exchangeRateController.getCatalog);
+router.get('/', authenticateToken, exchangeRateController.getCurrentExchangeRate);
+router.post('/clear-cache', authenticateToken, exchangeRateController.clearCache);
 
 export default router;

--- a/routes/exchangeRateRoutes.js
+++ b/routes/exchangeRateRoutes.js
@@ -12,12 +12,13 @@
 
 import express from 'express';
 import * as exchangeRateController from '../controllers/exchangeRateController.js';
+import { generalRateLimiter } from "../middleware/rateLimiters.js";
 import { authenticateToken } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.get('/catalog', authenticateToken, exchangeRateController.getCatalog);
-router.get('/', authenticateToken, exchangeRateController.getCurrentExchangeRate);
-router.post('/clear-cache', authenticateToken, exchangeRateController.clearCache);
+router.get('/catalog', generalRateLimiter, authenticateToken, exchangeRateController.getCatalog);
+router.get('/', generalRateLimiter, authenticateToken, exchangeRateController.getCurrentExchangeRate);
+router.post('/clear-cache', generalRateLimiter, authenticateToken, exchangeRateController.clearCache);
 
 export default router;

--- a/services/authorizationRuleService.js
+++ b/services/authorizationRuleService.js
@@ -73,31 +73,49 @@ const AuthorizationRuleService = {
   /**
    * Get the next approver based on authorization rule level configuration
    * @param {object} ruleLevel - The AuthorizationRuleLevel object with level_type and superior_level_number
-   * @param {number} requesterUserId - The ID of the user who created the request
+   * @param {number} requesterUserId - The ID of the user to get the boss from (for escalation reference)
    * @param {number} departmentId - The department of the requester
    * @param {number} societyGroupId - The society group ID
+   * @param {number} assignedTo - The user_id currently assigned (to avoid repeating)
    * @returns {number|null} The user_id of the next approver, or null if none found
    */
-  async getNextApproverForRuleLevel(ruleLevel, requesterUserId, departmentId, societyGroupId) {
+  async getNextApproverForRuleLevel(ruleLevel, requesterUserId, departmentId, societyGroupId, assignedTo = null) {
     try {
       if (ruleLevel.level_type === 'Jefe') {
         // Direct boss
         const boss = await User.getBossId(requesterUserId);
+
+        // Don't assign to the same person twice in a row
+        if (boss === assignedTo) {
+          return null;
+        }
         return boss;
       } else if (ruleLevel.level_type === 'Aleatorio') {
-        // Random approver from the department (permission-based, role-name agnostic)
-        let randomAuthorizer = await User.getRandomUserByPermissions(['travel:approve', 'travel:reject'], departmentId, societyGroupId);
+        // Random approver from the hierarchy above the current user
+        // Get all bosses of the current user up the chain
+        const bosses = [];
+        let currentUserId = requesterUserId;
+        let attempts = 0;
+        const maxLevels = 10; // Prevent infinite loops
 
-        // If selected approver == requester, retry a few times
-        if (randomAuthorizer && randomAuthorizer.user_id === requesterUserId) {
-          let attempts = 0;
-          while (attempts < 5 && randomAuthorizer && randomAuthorizer.user_id === requesterUserId) {
-            randomAuthorizer = await User.getRandomUserByPermissions(['travel:approve', 'travel:reject'], departmentId, societyGroupId);
-            attempts++;
+        while (currentUserId && attempts < maxLevels) {
+          const bossId = await User.getBossId(currentUserId);
+          if (!bossId || bossId === currentUserId) break; // No more bosses or circular reference
+
+          // Check if boss has required permissions
+          const bossHasPermission = await User.userHasAnyPermission(bossId, ['travel:approve', 'travel:reject'], societyGroupId);
+          if (bossHasPermission && bossId !== assignedTo && bossId !== requesterUserId) {
+            bosses.push(bossId);
           }
+
+          currentUserId = bossId;
+          attempts++;
         }
 
-        return randomAuthorizer ? randomAuthorizer.user_id : null;
+        // Return a random boss, or null if none available
+        if (bosses.length === 0) return null;
+        const randomIndex = Math.floor(Math.random() * bosses.length);
+        return bosses[randomIndex];
       } else if (ruleLevel.level_type === 'Nivel_Superior' || ruleLevel.level_type === 'Nivel Superior') {
         // N levels up the hierarchy
         const levelsUp = ruleLevel.superior_level_number || 1;

--- a/services/authorizerService.js
+++ b/services/authorizerService.js
@@ -165,21 +165,31 @@ const authorizeRequest = async (request_id, user_id, options = {}) => {
         }
 
         // Determine next approver based on rule level type
+        // Use the current assigned_to as the reference for hierarchy escalation
         new_assigned_to = await AuthorizationRuleService.getNextApproverForRuleLevel(
           nextRuleLevel,
-          request.user_id, // requester (original applicant)
+          request.assigned_to, // Current approver (escalate from them)
           requesterUser.department_id,
-          requesterUser.society_id
+          requesterUser.society_id,
+          request.assigned_to // Avoid assigning to the same person
         );
 
+        // If no approver found for this level, skip to next stage (Travel Agent or Accounts Payable)
         if (!new_assigned_to) {
-          throw {
-            status: 500,
-            message: `Could not determine next approver for rule level ${new_authorization_level}`
-          };
+          const needsTravelAgent = await Authorizer.requiresTravelAgencyServices(request_id);
+          if (needsTravelAgent) {
+            const travelAgent = await User.getRandomUserByPermissions(TRAVEL_AGENT_PERMISSIONS, requesterUser.department_id, requesterUser.society_id);
+            new_assigned_to = travelAgent ? travelAgent.user_id : null;
+            new_status_id = 4;
+          } else {
+            const accountsPayable = await User.getRandomUserByPermissions(ACCOUNTS_PAYABLE_PERMISSIONS, requesterUser.department_id, requesterUser.society_id);
+            new_assigned_to = accountsPayable ? accountsPayable.user_id : null;
+            new_status_id = 3;
+          }
+          console.log(`No approver available for rule level ${new_authorization_level}, routing to next stage`);
+        } else {
+          console.log(`Escalating to next level approver (user_id: ${new_assigned_to}), new authorization level: ${new_authorization_level}`);
         }
-
-        console.log(`Escalating to next level approver (user_id: ${new_assigned_to}), new authorization level: ${new_authorization_level}`);
       }
     }
 

--- a/services/email/emailService.js
+++ b/services/email/emailService.js
@@ -18,18 +18,18 @@ export async function sendEmails(requestId) {
 
   if (finalStates.includes(status)) {
     // Only send to applicant for final states
-    await sendMail(applicantId, requestId);
+    await sendMail(applicantId, requestId, 'applicant');
     return;
   }
 
   // For non-final states
   if (applicantId === assignedToId || !assignedToId) {
     // Only send one email if applicant and assigned_to are the same person or assigned_to is null
-    await sendMail(applicantId, requestId);
+    await sendMail(applicantId, requestId, 'applicant');
   } else {
     // Send to both applicant and assigned_to user
-    await sendMail(applicantId, requestId);
-    await sendMail(assignedToId, requestId);
+    await sendMail(applicantId, requestId, 'applicant');
+    await sendMail(assignedToId, requestId, 'assigned');
   }
 }
 

--- a/services/email/emailService.js
+++ b/services/email/emailService.js
@@ -19,15 +19,17 @@ export async function sendEmails(requestId) {
   if (finalStates.includes(status)) {
     // Only send to applicant for final states
     await sendMail(applicantId, requestId);
-  } else if (applicantId === assignedToId || !assignedToId) {
+    return;
+  }
+
+  // For non-final states
+  if (applicantId === assignedToId || !assignedToId) {
     // Only send one email if applicant and assigned_to are the same person or assigned_to is null
     await sendMail(applicantId, requestId);
   } else {
-    // Send to both applicant and assigned_to user (if assignedToId exists)
+    // Send to both applicant and assigned_to user
     await sendMail(applicantId, requestId);
-    if (assignedToId) {
-      await sendMail(assignedToId, requestId);
-    }
+    await sendMail(assignedToId, requestId);
   }
 }
 

--- a/services/email/mail.js
+++ b/services/email/mail.js
@@ -135,8 +135,7 @@ export async function sendMail(userId, requestId) {
       templateName = "applicant.html";
     }
   } else if (userRole === "Autorizador") {
-    // Si la solicitud fue cancelada, solo notificar cancelación, sin acciones
-    if (status === "Cancelado") {
+    if (status === "Cancelado" || status === "Rechazado" || status === "Finalizado") {
       templateName = "applicant.html";
     } else {
       templateName = "authorizer.html";

--- a/services/email/mail.js
+++ b/services/email/mail.js
@@ -48,13 +48,13 @@ const transporter = nodemailer.createTransport({
 const TEMPLATES_DIR = path.join(__dirname, 'templates');
 
 /**
- * Get the email subject line based on user role and request status
+ * Get the email subject line based on user type and request status
  * @param {string} status - The current status of the travel request
- * @param {string} userRole - The role of the user receiving the email
+ * @param {string} userType - The type of user ('applicant' or 'assigned')
  * @returns {string} The email subject line
  */
-const getEmailSubject = (status, userRole) => {
-  if (userRole === "Solicitante") {
+const getEmailSubject = (status, userType) => {
+  if (userType === "applicant") {
     switch (status) {
       case "Revisión":
         return "Solicitud en revisión";
@@ -75,26 +75,18 @@ const getEmailSubject = (status, userRole) => {
       default:
         return "Solicitud de viaje actualizada";
     }
-  } else if (userRole === "Autorizador") {
+  } else if (userType === "assigned") {
     switch (status) {
       case "Revisión":
         return "Revisión requerida";
-      default:
-        return "Solicitud de viaje actualizada";
-    }
-  } else if (userRole === "Cuentas por pagar") {
-    switch (status) {
       case "Cotización del Viaje":
         return "Cotización requerida";
-      case "Comprobación gastos del viaje":
-        return "Validación de comprobantes requerida";
-      default:
-        return "Solicitud de viaje actualizada";
-    }
-  } else if (userRole === "Agencia de viajes") {
-    switch (status) {
       case "Atención Agencia de Viajes":
         return "Atención requerida";
+      case "Comprobación gastos del viaje":
+        return "Validación de comprobantes requerida";
+      case "Validación de comprobantes":
+        return "Validación de comprobantes requerida";
       default:
         return "Solicitud de viaje actualizada";
     }
@@ -109,7 +101,7 @@ const getEmailSubject = (status, userRole) => {
  * @returns {Promise<void>}
  * @throws {Error} If email fails to send
  */
-export async function sendMail(userId, requestId) {
+export async function sendMail(userId, requestId, userType = 'applicant') {
   // Get request details
   const requestDataRows = await User.getTravelRequestById(requestId);
   const requestData = requestDataRows[0];
@@ -119,35 +111,39 @@ export async function sendMail(userId, requestId) {
 
   // Get current date in JSON format and slice to get only the date part (YYYY-MM-DD)
   const currentDate = new Date().toJSON().slice(0, 10);
-  
-  // Determine the email template to use based on the user's role and request status
+
+  // Determine the email template to use
   const status = requestData.request_status;
   const username = userData.user_name;
-  const userRole = userData.role_name;  
+  const userRole = userData.role_name;
   const email = userData.email;
 
   let templateName = "applicant.html"; // Default template
 
-  if (userRole === "Solicitante") {
+  // If applicant, always use applicant template
+  if (userType === 'applicant') {
     if (status === "Comprobación gastos del viaje") {
       templateName = "applicant-receipts.html";
     } else {
       templateName = "applicant.html";
     }
-  } else if (userRole === "Autorizador") {
-    if (status === "Cancelado" || status === "Rechazado" || status === "Finalizado") {
-      templateName = "applicant.html";
-    } else {
+  }
+  // If assigned, determine template based on permissions
+  else if (userType === 'assigned') {
+    const permissionKeys = await User.getUserPermissions(userId);
+    const permissionSet = new Set(permissionKeys);
+
+    if (permissionSet.has('travel:approve') || permissionSet.has('travel:reject')) {
       templateName = "authorizer.html";
+    } else if (permissionSet.has('receipts:approve')) {
+      if (status === "Cotización del Viaje") {
+        templateName = "accounts-payable-fee.html";
+      } else {
+        templateName = "accounts-payable-receipts.html";
+      }
+    } else if (permissionSet.has('travel:view_flights') || permissionSet.has('travel:view_hotels')) {
+      templateName = "travel-agent.html";
     }
-  } else if (userRole === "Cuentas por pagar") {
-    if (status === "Cotización del Viaje") {
-      templateName = "accounts-payable-fee.html";
-    } else {
-      templateName = "accounts-payable-receipts.html";
-    }
-  } else if (userRole === "Agencia de viajes") {
-    templateName = "travel-agent.html";
   }
   
   try {
@@ -208,7 +204,7 @@ export async function sendMail(userId, requestId) {
     const mailOptions = {
       from: `Portal de Viajes <${process.env.MAIL_USER}>`,
       to: email,
-      subject: getEmailSubject(status, userRole),
+      subject: getEmailSubject(status, userType),
       html: htmlContent,
     };
     

--- a/services/email/templates/accounts-payable-fee.html
+++ b/services/email/templates/accounts-payable-fee.html
@@ -37,7 +37,7 @@
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder a tu portal en 
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/email/templates/accounts-payable-receipts.html
+++ b/services/email/templates/accounts-payable-receipts.html
@@ -36,7 +36,7 @@
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder a tu portal en 
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/email/templates/applicant-receipts.html
+++ b/services/email/templates/applicant-receipts.html
@@ -36,7 +36,7 @@
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder a tu portal en 
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/email/templates/applicant.html
+++ b/services/email/templates/applicant.html
@@ -36,7 +36,7 @@
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder a tu portal en 
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/email/templates/authorizer.html
+++ b/services/email/templates/authorizer.html
@@ -36,7 +36,7 @@
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder al sistema en
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/email/templates/travel-agent.html
+++ b/services/email/templates/travel-agent.html
@@ -30,14 +30,14 @@
       <p>Revisa los detalles de la solicitud y gestiona los servicios de viaje necesarios:</p>
       
       <p class="text-center">
-        <a href="{{portalUrl}}/atender-solicitud/{{requestId}}" class="btn">Ver Detalles del Viaje</a>
+        <a href="{{portalUrl}}/atender-solicitud/{{requestId}}" class="btn">Atender Solicitud</a>
       </p>
     </div>
 
     <div class="footer">
       <p>
         Si deseas más información, puedes acceder a tu portal en 
-        <a href="{{portalUrl}}/login">{{portalUrl}}/login</a>
+        <a href="{{portalUrl}}">{{portalUrl}}</a>
       </p>
     </div>
   </div>

--- a/services/requestService.js
+++ b/services/requestService.js
@@ -109,7 +109,7 @@ const RequestService = {
         throw new Error(`Request ${requestId} not found`);
       }
 
-      return row.request_status?.status || null;
+      return row.Request_status?.status || null;
 
     } catch (error) {
       console.error('Error getting request status:', error);

--- a/services/requestService.js
+++ b/services/requestService.js
@@ -121,7 +121,7 @@ const RequestService = {
    * Get requests visible to a user (requester OR assignee) with filtering and sorting
    * @param {number} userId - User ID making the request
    * @param {number} societyId - User's society ID for access control
-   * @param {Object} rawFilters - Raw query filters from request: { status, sort }
+   * @param {Object} rawFilters - Raw query filters from request: { status, sort, assignedOnly }
    * @returns {Promise<Array>} Formatted requests array
    * @throws {Error} If userId or societyId missing or database error
    */
@@ -144,12 +144,13 @@ const RequestService = {
 /**
  * Normalize and validate filter parameters from query string
  * @param {Object} rawFilters - Raw filters object
- * @returns {Object} Normalized { status, sort }
+ * @returns {Object} Normalized { status, sort, assignedOnly }
  */
-function normalizeRequestFilters({ status, sort } = {}) {
+function normalizeRequestFilters({ status, sort, assignedOnly } = {}) {
   return {
     status: typeof status === 'string' ? status.trim() || null : null,
     sort: sort === 'asc' ? 'asc' : 'desc',
+    assignedOnly: assignedOnly === true,
   };
 }
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -62,16 +62,16 @@ export async function authenticateUser(username, password, req) {
     const user = await userModel.getUserUsername(username);
     
     if (!user || user.length === 0) {
-      throw new Error("Invalid username or password");
+      throw new Error("Usuario o contraseña inválidos");
     }
     
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
-      throw new Error("Invalid username or password");
+      throw new Error("Usuario o contraseña inválidos");
     }
 
     if (!user.active) {
-      throw new Error("User acccount is inactive")
+      throw new Error("Esta cuenta está inactiva")
     }
 
     const enforceIpBinding = String(process.env.ENFORCE_TOKEN_IP_BINDING || 'false').toLowerCase() === 'true';
@@ -99,7 +99,7 @@ export async function authenticateUser(username, password, req) {
       permission_keys: user.permission_keys || []
     };
   } catch (error) {
-    throw new Error(`Authentication failed: ${error.message}`);
+    throw new Error("Usuario o contraseña inválidos");
   }
 }
 


### PR DESCRIPTION
<!-- -----------------------------------------------------------------
Pull Request Template

Select the type of PR below and complete the relevant checklist.
------------------------------------------------------------------ -->

# Pull Request Type

Select one (required):

- [ ] **Feature** - New functionality or User Story implementation
- [x] **Chore** - Maintenance, refactoring, docs, or tooling
- [x] **Hotfix** - Critical bug fix for production
- [ ] **Documentation** - Documentation-only changes
- [ ] **Style** - Code formatting or linting with no functional change

---

**Description of feature:**

_What does this PR implement?_

### Soft Deletion and Active Status Filtering

* Added an `active` boolean column (default `true`) to the `Society`, `SocietyGroup`, and `AuthorizationRule` models in the Prisma schema and corresponding migration files. All queries for these entities now filter by `active: true`, ensuring only active records are returned.

* Updated deletion operations for `Society`, `SocietyGroup`, and `AuthorizationRule` to perform a soft delete by setting `active: false` instead of removing records. Deleting a group also deactivates all societies in that group.

### Authorization Rule Management

* All queries for authorization rules now return only active rules. The deletion of an authorization rule now deactivates it, preserving its use for existing requests while hiding it from new ones.

### Request Visibility and Filtering

* Enhanced the request retrieval logic to support an `assignedOnly` filter, allowing users to fetch only requests assigned to them. The backend now distinguishes between requests created by the user and those assigned to the user.

* Improved authorization checks so that users can only view requests they created, are assigned to, or if they are an admin.

### User Permissions and Approver Assignment

* Added a method to fetch user permissions and improved logic for determining the next approver in an authorization rule, ensuring that the same user is not assigned twice in a row and that only users with the correct permissions are selected.

### Database Seeding and Reference Data

* Modified seeding logic to upsert request statuses with fixed IDs for consistency in backend references and removed redundant default rule and refund policy data.

### Export Accountability Data Adjustments

* Exportation of accountability data is now done per society group instead of globally.

---

## Pre-Submission Checklist (All PRs)

- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) guide
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] PR targets the appropriate branch (`main` on dittravel)
- [x] Code has been tested locally
- [x] No console errors or warnings
