### PR TITLE
[Feat] Accounting accounts endpoints and small fixes

### DIFF
--- a/controllers/accountController.js
+++ b/controllers/accountController.js
@@ -1,0 +1,113 @@
+/**
+ * Accounting Accounts Controller
+ *
+ * HTTP handlers for accounting accounts management
+ */
+
+import AuditLogService from '../services/auditLogService.js';
+import AccountService from '../services/accountService.js';
+
+export async function getAccounts(req, res) {
+  try {
+    const societyId = req.user.society_id;
+    const accounts = await AccountService.getAccounts(societyId, req.user);
+    return res.status(200).json(accounts);
+  } catch (error) {
+    console.error('Error getting accounting accounts:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export async function getAccountById(req, res) {
+  try {
+    const account = await AccountService.getAccountById(Number(req.params.account_id), req.user);
+    return res.status(200).json(account);
+  } catch (error) {
+    console.error('Error getting accounting account:', error);
+    return res.status(error.status || 500).json({ error: error.message || 'Internal server error' });
+  }
+}
+
+export async function createAccount(req, res) {
+  try {
+    const accountData = {
+      ...req.body,
+      society_id: req.user.society_id,
+    };
+    const account = await AccountService.createAccount(accountData, req.user);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'ACCOUNT_CREATED',
+      entityType: 'Account',
+      entityId: account.account_id,
+      metadata: {
+        code: account.account_code,
+        name: account.account_name,
+        type: account.account_type,
+      },
+    });
+    return res.status(201).json(account);
+  } catch (error) {
+    console.error('Error creating accounting account:', error);
+    return res.status(error.status || 500).json({ error: error.message || 'Internal server error' });
+  }
+}
+
+export async function updateAccount(req, res) {
+  try {
+    const account = await AccountService.updateAccount(Number(req.params.account_id), req.body, req.user);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'ACCOUNT_UPDATED',
+      entityType: 'Account',
+      entityId: account.id,
+      metadata: {
+        code: account.code,
+        name: account.name,
+        type: account.type,
+      },
+    });
+    return res.status(200).json(account);
+  } catch (error) {
+    console.error('Error updating accounting account:', error);
+    return res.status(error.status || 500).json({ error: error.message || 'Internal server error' });
+  }
+}
+
+export async function deleteAccount(req, res) {
+  try {
+    const deletedAccount = await AccountService.deleteAccount(Number(req.params.account_id), req.user);
+    await AuditLogService.recordAuditLogFromRequest(req, {
+      actionType: 'ACCOUNT_DELETED',
+      entityType: 'Account',
+      entityId: deletedAccount.id,
+      metadata: {
+        code: deletedAccount.code,
+        name: deletedAccount.name,
+        type: deletedAccount.type,
+      },
+    });
+    return res.status(204).send();
+  } catch (error) {
+    console.error('Error deleting account:', error);
+    return res.status(error.status || 500).json({ error: error.message || 'Internal server error' });
+  }
+}
+
+export async function getCostCenters(req, res) {
+  try {
+    const societyId = req.user.society_id;
+    const costCenters = await AccountService.getCostCentersBySociety(societyId);
+    return res.status(200).json(costCenters);
+  } catch (error) {
+    console.error('Error getting cost centers:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+export default {
+  getAccounts,
+  getAccountById,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  getCostCenters,
+};

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ import societyGroupRoutes from "./routes/societyGroupRoutes.js";
 import societyRoutes from "./routes/societyRoutes.js";
 import refundRoutes from "./routes/refundRoutes.js";
 import requestRoutes from "./routes/requestRoutes.js";
+import accountRoutes from "./routes/accountRoutes.js";
 
 // Import MongoDB connection for file storage
 import { connectMongo } from './services/fileStorage.js';
@@ -102,6 +103,7 @@ app.use("/api/society-groups", societyGroupRoutes);
 app.use("/api/societies", societyRoutes);
 app.use("/api/refunds", refundRoutes);
 app.use("/api/requests", requestRoutes);
+app.use("/api/accounts", accountRoutes);
 
 // Connect to MongoDB for file storage
 connectMongo().catch(err => console.error('Failed to connect to MongoDB:', err));

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -50,6 +50,11 @@ export const validateId = [
     .isInt()
     .toInt()
     .withMessage('Group ID must be a valid number'),
+  param('account_id')
+    .optional()
+    .isInt()
+    .toInt()
+    .withMessage('Account ID must be a valid number'),
   (req, res, next) => {
     if (
       !req.params.id &&
@@ -59,7 +64,8 @@ export const validateId = [
       !req.params.policy_id &&
       !req.params.department_id &&
       !req.params.society_id &&
-      !req.params.group_id
+      !req.params.group_id &&
+      !req.params.account_id
     ) {
       return res.status(400).json({ error: "At least one ID needs to be provided" });
     }

--- a/models/accountModel.js
+++ b/models/accountModel.js
@@ -1,0 +1,93 @@
+/**
+ * Accounting Accounts Controller
+ *
+ * Data access layer for accounting accounts
+ */
+
+import { prisma } from '../lib/prisma.js';
+
+export async function getAccounts(societyId) {
+  return await prisma.account.findMany({
+    where: {
+      active: true,
+      society_id: societyId
+    },
+    include: {
+      CostCenter: {
+        select: {
+          cost_center_name: true
+        }
+      }
+    }
+  });
+}
+
+export async function getAccountById(accountId, societyId) {
+  return await prisma.account.findUnique({
+    where: {
+      active: true,
+      account_id: accountId,
+      society_id: societyId
+    },
+    include: {
+      CostCenter: {
+        select: {
+          cost_center_name: true
+        }
+      }
+    }
+  });
+}
+
+export async function createAccount(data) {
+  return await prisma.account.create({
+    data: {
+      account_code: data.account_code,
+      account_name: data.account_name,
+      account_type: data.account_type,
+      description: data.description,
+      society_id: data.society_id,
+      cost_center_id: Number(data.cost_center_id),
+    }
+  });
+}
+
+export async function updateAccount(accountId, data) {
+  return await prisma.account.update({
+    where: { account_id: accountId },
+    data: {
+      account_name: data.account_name,
+      account_type: data.account_type,
+      description: data.description,
+      cost_center_id: Number(data.cost_center_id),
+    }
+  });
+}
+
+export async function deleteAccount(accountId) {
+  return await prisma.account.update({
+    where: { account_id: accountId },
+    data: { active: false }
+  });
+}
+
+export async function getCostCentersBySociety(societyId) {
+  return await prisma.costCenter.findMany({
+    where: { society_id: societyId },
+    select: {
+      cost_center_id: true,
+      cost_center_name: true,
+      cost_center_code: true,
+    },
+    orderBy: { cost_center_name: 'asc' }
+  });
+}
+
+export default {
+  getAccounts,
+  getAccountById,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  getCostCentersBySociety
+};

--- a/prisma/migrations/20260530171644_update_account_unique_key/migration.sql
+++ b/prisma/migrations/20260530171644_update_account_unique_key/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[account_code,society_id]` on the table `Account` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX `Account_account_code_key` ON `Account`;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `Account_account_code_society_id_key` ON `Account`(`account_code`, `society_id`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -420,7 +420,7 @@ model Society {
 /// General ledger accounts for financial classification
 model Account {
   account_id          Int                   @id @default(autoincrement())
-  account_code        String                @unique @db.VarChar(20)
+  account_code        String                @db.VarChar(20)
   account_name        String                @db.VarChar(100)
   account_type        String                @db.VarChar(50)
   description         String?               @db.VarChar(255)
@@ -433,6 +433,7 @@ model Account {
   CostCenter          CostCenter?           @relation(fields: [cost_center_id], references: [cost_center_id], map: "fk_account_costcenter")
   ReceiptType_Account ReceiptType_Account[]
 
+  @@unique([account_code, society_id])
   @@index([society_id])
   @@index([cost_center_id])
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -47,8 +47,6 @@ async function seedDefaultSocietyGroupAndSociety() {
   }
 }
 
-
-
 /**
  * Seed the database with base data
  * @returns {Promise<void>} Resolves when seeding is complete.

--- a/prisma/seedDummy.js
+++ b/prisma/seedDummy.js
@@ -224,20 +224,23 @@ async function seedDummyAccountability(societies) {
   // Create accounts for each society
   for (const account of ACCOUNTS) {
     for (const society of societies) {
-      await prisma.account.upsert({
-        where: { account_code: account.account_code },
-        create: {
+      const existing = await prisma.account.findFirst({
+        where: {
           account_code: account.account_code,
-          account_name: account.account_name,
-          account_type: account.account_type,
-          society_id: society.id,
-        },
-        update: {
-          account_name: account.account_name,
-          account_type: account.account_type,
           society_id: society.id,
         },
       });
+
+      if (!existing) {
+        await prisma.account.create({
+          data: {
+            account_code: account.account_code,
+            account_name: account.account_name,
+            account_type: account.account_type,
+            society_id: society.id,
+          },
+        });
+      }
     }
   }
 
@@ -248,7 +251,7 @@ async function seedDummyAccountability(societies) {
       select: { receipt_type_id: true },
     });
 
-    const account = await prisma.account.findUnique({
+    const account = await prisma.account.findFirst({
       where: { account_code: accountCode },
       select: { account_id: true },
     });

--- a/prisma/seedShared.js
+++ b/prisma/seedShared.js
@@ -286,6 +286,11 @@ export async function seedReferenceData(prisma, defaultSocietyId) {
     { permission_key: 'superadmin:manage_groups', permission_name: 'Administrar grupos de sociedades', module: 'superadmin', action: 'manage_groups', description: 'Create, update and delete society groups and bootstrap tenant data' },
     { permission_key: 'superadmin:manage_master_admins', permission_name: 'Administrar administradores maestros', module: 'superadmin', action: 'manage_master_admins', description: 'Manage top-level superadmin users' },
     { permission_key: 'superadmin:view_group_audit_log', permission_name: 'Ver bitácora por grupo', module: 'superadmin', action: 'view_group_audit_log', description: 'Read audit logs filtered by society group' },
+    // Accounting Accounts
+    { permission_key: 'accounts:view', permission_name: 'Ver cuentas contables', module: 'accounts', action: 'view', description: 'View accounting accounts' },
+    { permission_key: 'accounts:create', permission_name: 'Crear cuentas contables', module: 'accounts', action: 'create', description: 'Create accounting accounts' },
+    { permission_key: 'accounts:edit', permission_name: 'Editar cuentas contables', module: 'accounts', action: 'edit', description: 'Edit accounting accounts' },
+    { permission_key: 'accounts:delete', permission_name: 'Eliminar cuentas contables', module: 'accounts', action: 'delete', description: 'Deactivate accounting accounts' },
   ];
 
   await upsertOrderedRecords(prisma.permission, permissions, (item) => ({
@@ -356,6 +361,11 @@ export async function seedReferenceData(prisma, defaultSocietyId) {
       // Configuration
       'auth_rules:manage',
       'refund_policies:manage',
+      // Accounting accounts
+      'accounts:view',
+      'accounts:create',
+      'accounts:edit',
+      'accounts:delete',
     ],
     'Superadministrador': [
       // Society groups

--- a/prisma/seedShared.js
+++ b/prisma/seedShared.js
@@ -468,7 +468,7 @@ export async function seedReferenceData(prisma, defaultSocietyId) {
     await prisma.refundPolicy.create({
       data: {
         policy_name: `Política Defecto ${societyName}`,
-        min_amount: 0,
+        min_amount: 1,
         max_amount: 100000,
         submission_deadline_days: 30,
         society_id: defaultSocietyId,

--- a/routes/accountRoutes.js
+++ b/routes/accountRoutes.js
@@ -1,0 +1,68 @@
+/**
+ * Accounting Accounts Routes
+ *
+ * Endpoints for managing accounting accounts
+ */
+
+import express from 'express';
+import * as accountController from '../controllers/accountController.js';
+import { authenticateToken, authorizePermission, authorizeRole, validateSocietyAccess } from '../middleware/auth.js';
+import { validateId, validateInputs } from '../middleware/validation.js';
+import { generalRateLimiter } from '../middleware/rateLimiters.js';
+
+const router = express.Router();
+
+router.route('/cost-centers')
+  .get(
+    generalRateLimiter,
+    authenticateToken,
+    accountController.getCostCenters
+  );
+
+router.route('/')
+  .get(
+    generalRateLimiter,
+    authenticateToken,
+    authorizePermission(['accounts:view'], { mode: 'any' }),
+    validateSocietyAccess('user'),
+    accountController.getAccounts
+  )
+  .post(
+    generalRateLimiter,
+    authenticateToken,
+    authorizePermission(['accounts:create'], { mode: 'any' }),
+    validateSocietyAccess('user'),
+    validateInputs,
+    accountController.createAccount
+  );
+
+router.route('/:account_id')
+  .get(
+    generalRateLimiter,
+    authenticateToken,
+    authorizePermission(['accounts:view'], { mode: 'any' }),
+    validateSocietyAccess('user'),
+    validateId,
+    validateInputs,
+    accountController.getAccountById
+  )
+  .put(
+    generalRateLimiter,
+    authenticateToken,
+    authorizePermission(['accounts:edit'], { mode: 'any' }),
+    validateSocietyAccess('user'),
+    validateId,
+    validateInputs,
+    accountController.updateAccount
+  )
+  .delete(
+    generalRateLimiter,
+    authenticateToken,
+    authorizePermission(['accounts:delete'], { mode: 'any' }),
+    validateSocietyAccess('user'),
+    validateId,
+    validateInputs,
+    accountController.deleteAccount
+  );
+
+export default router;

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -72,38 +72,38 @@ router.route("/get-roles")
   .get(
     generalRateLimiter,
     authenticateToken,
-    authorizePermission(['users:view', 'users:create', 'users:edit'], { mode: 'any' }),
+    authorizePermission(['roles:manage'], { mode: 'any' }),
     adminController.getRoles,
   );
 
 // Get role details by ID
 router.route('/roles/:role_id')
-  .get(generalRateLimiter, authenticateToken, authorizePermission(['users:view']), adminController.getRoleById);
+  .get(generalRateLimiter, authenticateToken, authorizePermission(['roles:manage']), adminController.getRoleById);
 
 // Create role
 router.route('/create-role')
-  .post(generalRateLimiter, authenticateToken, authorizePermission(['users:create']), adminController.createRole);
+  .post(generalRateLimiter, authenticateToken, authorizePermission(['roles:manage']), adminController.createRole);
 
 // Update role
 router.route('/update-role/:role_id')
-  .put(generalRateLimiter, authenticateToken, authorizePermission(['users:edit']), adminController.updateRole);
+  .put(generalRateLimiter, authenticateToken, authorizePermission(['roles:manage']), adminController.updateRole);
 
 // Get default role for current society group
 router.route('/get-default-role')
   .get(
     generalRateLimiter,
     authenticateToken,
-    authorizePermission(['users:view', 'users:create', 'users:edit'], { mode: 'any' }),
+    authorizePermission(['roles:manage'], { mode: 'any' }),
     adminController.getDefaultRole,
   );
 
 // Set default role for current society group
 router.route('/set-default-role/:role_id')
-  .put(generalRateLimiter, authenticateToken, authorizePermission(['users:edit']), adminController.setDefaultRole);
+  .put(generalRateLimiter, authenticateToken, authorizePermission(['roles:manage']), adminController.setDefaultRole);
 
 // Delete role
 router.route('/delete-role/:role_id')
-  .delete(generalRateLimiter, authenticateToken, authorizePermission(['users:delete']), adminController.deleteRole);
+  .delete(generalRateLimiter, authenticateToken, authorizePermission(['roles:manage']), adminController.deleteRole);
 
 // Get an auth rule by ID
 router.route("/auth-rules/:rule_id")

--- a/services/accountService.js
+++ b/services/accountService.js
@@ -1,0 +1,79 @@
+/**
+ * Accounting Accounts Service
+ *
+ * Business logic for accounting accounts management.
+ */
+
+import AccountModel from '../models/accountModel.js';
+
+export async function getAccounts(societyId, currentUser) {
+  if (!societyId) {
+    const error = new Error('Society ID is required');
+    error.status = 400;
+    throw error;
+  }
+
+  const accounts = await AccountModel.getAccounts(societyId);
+  return Array.isArray(accounts) ? accounts : [];
+}
+
+export async function getAccountById(accountId, currentUser) {
+  const account = await AccountModel.getAccountById(accountId, currentUser.society_id);
+
+  if (!account) {
+    const error = new Error('Account not found');
+    error.status = 404;
+    throw error;
+  }
+
+  return account;
+}
+
+export async function createAccount(data, currentUser) {
+  return await AccountModel.createAccount(data);
+}
+
+export async function updateAccount(accountId, data, currentUser) {
+  const account = await AccountModel.getAccountById(accountId);
+
+  if (!account) {
+    const error = new Error('Account not found');
+    error.status = 404;
+    throw error;
+  }
+
+  return await AccountModel.updateAccount(accountId, data);
+}
+
+export async function deleteAccount(accountId, currentUser) {
+  const account = await AccountModel.getAccountById(accountId);
+
+  if (!account) {
+    const error = new Error('Account not found');
+    error.status = 404;
+    throw error;
+  }
+
+  await AccountModel.deleteAccount(accountId);
+  return account;
+}
+
+export async function getCostCentersBySociety(societyId) {
+  if (!societyId) {
+    const error = new Error('Society ID is required');
+    error.status = 400;
+    throw error;
+  }
+
+  const costCenters = await AccountModel.getCostCentersBySociety(societyId);
+  return costCenters || [];
+}
+
+export default {
+  getAccounts,
+  getAccountById,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  getCostCentersBySociety,
+};


### PR DESCRIPTION
<!-- -----------------------------------------------------------------
Pull Request Template

Select the type of PR below and complete the relevant checklist.
------------------------------------------------------------------ -->

# Pull Request Type

Select one (required):

- [x] **Feature** - New functionality or User Story implementation
- [x] **Chore** - Maintenance, refactoring, docs, or tooling
- [ ] **Hotfix** - Critical bug fix for production
- [ ] **Documentation** - Documentation-only changes
- [ ] **Style** - Code formatting or linting with no functional change

---

**Description of feature:**

_What does this PR implement?_

**Accounting Accounts Management**

- Added routes, controller, service and model for managing accounting accounts following the architecture layers.
- Modified the `Account` model to enforce uniqueness on the combination of `account_code` and `society_id` instead of just `account_code`, updating both the Prisma schema and migration files.
- Added new permissions for accounting accounts (`accounts:view`, `accounts:create`, `accounts:edit`, `accounts:delete`) and assigned them to admins in the seed data.

**Small Improvements**

* Updated admin routes to use the `roles:manage` permission for all role management endpoints for consistency.
* Minor fix to the default refund policy seed value.

---

## Pre-Submission Checklist (All PRs)

- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) guide
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] PR targets the appropriate branch (`main` on dittravel)
- [x] Code has been tested locally
- [x] No console errors or warnings
